### PR TITLE
feat(FlatMap): replace Mercator projection with orthographic globe effect

### DIFF
--- a/client/src/components/game/FlatMap.tsx
+++ b/client/src/components/game/FlatMap.tsx
@@ -82,13 +82,18 @@ export function FlatMap({
   const [selectedScreenPos, setSelectedScreenPos] = useState<{ x: number; y: number } | null>(null);
   const lastPosUpdateRef = useRef(0);
 
-  const [camera, setCamera] = useState({ x: 0, y: 0, zoom: 1 });
+  // Globe camera: centerLat/centerLng is the point at the center of the visible globe face
+  const [camera, setCamera] = useState({ centerLat: 0, centerLng: 0, zoom: 1 });
+  // Keep a ref for use inside pointer handlers without stale closure issues
+  const cameraRef = useRef(camera);
+  useEffect(() => { cameraRef.current = camera; }, [camera]);
 
   const playerMap = useMemo(() => {
     const m = new Map<string, string>();
     players?.forEach(p => m.set(p.id, p.name));
     return m;
   }, [players]);
+
   const isDragging = useRef(false);
   const lastMouse = useRef({ x: 0, y: 0 });
   const lastPinchDist = useRef(0);
@@ -124,49 +129,76 @@ export function FlatMap({
     return map;
   }, [parcels]);
 
-  const getPlotColor = useCallback(
-    (p: LandParcel) => {
-      if (p.id === selectedParcelId) return COLORS.selected;
-      if (p.id === hoveredPlotId) return COLORS.hover;
-      if (p.ownerId) {
-        if (currentPlayerId && p.ownerId === currentPlayerId) {
-          return COLORS.player;
-        }
-        return COLORS.enemy;
-      }
-      return COLORS.unclaimed;
+  // Compute the globe's pixel radius from canvas dimensions and zoom level.
+  // The 0.9 factor leaves a small margin so the atmosphere glow is visible.
+  const getGlobeRadius = useCallback(
+    (canvasW: number, canvasH: number) => {
+      return Math.min(canvasW, canvasH) / 2 * camera.zoom * 0.9;
     },
-    [selectedParcelId, currentPlayerId, hoveredPlotId]
+    [camera.zoom]
   );
 
+  /**
+   * Orthographic globe projection.
+   * Maps a lat/lng to a 2-D screen position by projecting onto the visible
+   * hemisphere centered on camera.centerLat / camera.centerLng.
+   * Returns null when the point is on the back hemisphere (not visible).
+   */
   const latLngToScreen = useCallback(
-    (lat: number, lng: number, canvasW: number, canvasH: number) => {
-      const mapW = canvasW * camera.zoom;
-      const mapH = canvasH * camera.zoom;
-      const x = ((lng + 180) / 360) * mapW + camera.x;
-      const y = ((90 - lat) / 180) * mapH + camera.y;
-      return { x, y };
+    (lat: number, lng: number, canvasW: number, canvasH: number): { x: number; y: number } | null => {
+      const R = getGlobeRadius(canvasW, canvasH);
+      const φ  = lat  * Math.PI / 180;
+      const λ  = lng  * Math.PI / 180;
+      const φ0 = camera.centerLat * Math.PI / 180;
+      const λ0 = camera.centerLng * Math.PI / 180;
+
+      // cos(angular distance from center) — negative means behind the globe
+      const cosC =
+        Math.sin(φ0) * Math.sin(φ) +
+        Math.cos(φ0) * Math.cos(φ) * Math.cos(λ - λ0);
+      if (cosC < 0) return null;
+
+      const x = R * Math.cos(φ) * Math.sin(λ - λ0);
+      const y = -R * (Math.cos(φ0) * Math.sin(φ) - Math.sin(φ0) * Math.cos(φ) * Math.cos(λ - λ0));
+
+      return { x: canvasW / 2 + x, y: canvasH / 2 + y };
     },
-    [camera]
+    [camera, getGlobeRadius]
   );
 
+  /**
+   * Inverse orthographic projection.
+   * Maps a screen pixel back to lat/lng.
+   * Returns null if the pixel is outside the globe circle.
+   */
   const screenToLatLng = useCallback(
-    (sx: number, sy: number, canvasW: number, canvasH: number) => {
-      const mapW = canvasW * camera.zoom;
-      const mapH = canvasH * camera.zoom;
-      const lng = ((sx - camera.x) / mapW) * 360 - 180;
-      const lat = 90 - ((sy - camera.y) / mapH) * 180;
-      return { lat, lng };
+    (sx: number, sy: number, canvasW: number, canvasH: number): { lat: number; lng: number } | null => {
+      const R  = getGlobeRadius(canvasW, canvasH);
+      const nx = (sx - canvasW / 2) / R;
+      const ny = -(sy - canvasH / 2) / R;
+      const ρ  = Math.sqrt(nx * nx + ny * ny);
+      if (ρ > 1) return null;
+
+      const c    = Math.asin(Math.min(1, ρ));
+      const φ0   = camera.centerLat * Math.PI / 180;
+      const λ0   = camera.centerLng * Math.PI / 180;
+      const sinC = Math.sin(c);
+      const cosC = Math.cos(c);
+
+      const φ = Math.asin(cosC * Math.sin(φ0) + (ρ > 0 ? ny * sinC * Math.cos(φ0) / ρ : 0));
+      const λ = λ0 + Math.atan2(nx * sinC, ρ * Math.cos(φ0) * cosC - ny * Math.sin(φ0) * sinC);
+
+      return { lat: φ * 180 / Math.PI, lng: λ * 180 / Math.PI };
     },
-    [camera]
+    [camera, getGlobeRadius]
   );
 
   const getPlotSize = useCallback(
-    (canvasW: number) => {
-      const baseSize = Math.max(2, (canvasW * camera.zoom) / 320);
-      return baseSize;
+    (canvasW: number, canvasH: number) => {
+      const R = getGlobeRadius(canvasW, canvasH);
+      return Math.max(2, R / 90);
     },
-    [camera.zoom]
+    [getGlobeRadius]
   );
 
   useEffect(() => {
@@ -184,30 +216,38 @@ export function FlatMap({
     const render = () => {
       const dpr = window.devicePixelRatio || 1;
       const rect = container.getBoundingClientRect();
-      const needsResize = canvas.width !== Math.round(rect.width * dpr) || canvas.height !== Math.round(rect.height * dpr);
+      const needsResize =
+        canvas.width  !== Math.round(rect.width  * dpr) ||
+        canvas.height !== Math.round(rect.height * dpr);
       if (needsResize) {
-        canvas.width = rect.width * dpr;
+        canvas.width  = rect.width  * dpr;
         canvas.height = rect.height * dpr;
-        canvas.style.width = `${rect.width}px`;
+        canvas.style.width  = `${rect.width}px`;
         canvas.style.height = `${rect.height}px`;
       }
       ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
 
-      const w = rect.width;
-      const h = rect.height;
+      const w  = rect.width;
+      const h  = rect.height;
+      const cx = w / 2;
+      const cy = h / 2;
+      const R  = getGlobeRadius(w, h);
 
+      // ── Space background ──────────────────────────────────────────────────
       ctx.fillStyle = COLORS.background;
       ctx.fillRect(0, 0, w, h);
 
+      // ── Stars ─────────────────────────────────────────────────────────────
       for (const star of stars) {
         const twinkle = Math.sin(pulse * star.twinkleSpeed) * 0.3 + 0.7;
-        const alpha = star.brightness * twinkle;
+        const alpha   = star.brightness * twinkle;
         ctx.fillStyle = `rgba(200, 220, 255, ${alpha})`;
         ctx.beginPath();
         ctx.arc(star.x * w, star.y * h, star.size, 0, Math.PI * 2);
         ctx.fill();
       }
 
+      // ── Shooting stars ────────────────────────────────────────────────────
       nextShootingStarRef.current--;
       if (nextShootingStarRef.current <= 0) {
         const angle = Math.random() * 0.4 + 0.2;
@@ -223,9 +263,8 @@ export function FlatMap({
         });
         nextShootingStarRef.current = Math.random() * 300 + 150;
       }
-
       for (let i = shootingStars.length - 1; i >= 0; i--) {
-        const ss = shootingStars[i];
+        const ss    = shootingStars[i];
         ss.x += ss.vx;
         ss.y += ss.vy;
         ss.life++;
@@ -233,105 +272,108 @@ export function FlatMap({
         if (alpha <= 0) { shootingStars.splice(i, 1); continue; }
         const tailX = ss.x - ss.vx * 8;
         const tailY = ss.y - ss.vy * 8;
-        const grad = ctx.createLinearGradient(ss.x, ss.y, tailX, tailY);
+        const grad  = ctx.createLinearGradient(ss.x, ss.y, tailX, tailY);
         grad.addColorStop(0, `rgba(255, 255, 255, ${alpha * 0.9})`);
         grad.addColorStop(1, `rgba(150, 200, 255, 0)`);
         ctx.strokeStyle = grad;
-        ctx.lineWidth = 1.5;
+        ctx.lineWidth   = 1.5;
         ctx.beginPath();
         ctx.moveTo(ss.x, ss.y);
         ctx.lineTo(tailX, tailY);
         ctx.stroke();
       }
 
-      const mapW = w * camera.zoom;
-      const mapH = h * camera.zoom;
+      // ── Atmosphere glow ring (drawn outside the globe circle) ─────────────
+      const atmosGrad = ctx.createRadialGradient(cx, cy, R * 0.96, cx, cy, R * 1.14);
+      atmosGrad.addColorStop(0,   "rgba(40, 120, 255, 0.50)");
+      atmosGrad.addColorStop(0.4, "rgba(20,  80, 200, 0.20)");
+      atmosGrad.addColorStop(1,   "rgba(10,  40, 120, 0)");
+      ctx.fillStyle = atmosGrad;
+      ctx.beginPath();
+      ctx.arc(cx, cy, R * 1.14, 0, Math.PI * 2);
+      ctx.fill();
 
+      // ── Everything below is clipped to the globe circle ───────────────────
+      ctx.save();
+      ctx.beginPath();
+      ctx.arc(cx, cy, R, 0, Math.PI * 2);
+      ctx.clip();
+
+      // Map image as the globe face (flat image stretched into the circle —
+      // not a pixel-perfect warp, but gives the correct visual impression of
+      // a globe with a visible surface texture).
       if (mapImageLoaded.current && mapImageRef.current) {
-        ctx.globalAlpha = 0.55;
-        ctx.drawImage(mapImageRef.current, camera.x, camera.y, mapW, mapH);
+        ctx.globalAlpha = 0.45;
+        ctx.drawImage(mapImageRef.current, cx - R, cy - R, R * 2, R * 2);
         ctx.globalAlpha = 1.0;
+      } else {
+        ctx.fillStyle = "#0a1628";
+        ctx.fillRect(cx - R, cy - R, R * 2, R * 2);
       }
 
-      const glowSize = 40;
-      const topGlow = ctx.createLinearGradient(0, camera.y, 0, camera.y + glowSize);
-      topGlow.addColorStop(0, "rgba(30, 80, 180, 0.15)");
-      topGlow.addColorStop(1, "rgba(30, 80, 180, 0)");
-      ctx.fillStyle = topGlow;
-      ctx.fillRect(camera.x, camera.y, mapW, glowSize);
-
-      const bottomGlow = ctx.createLinearGradient(0, camera.y + mapH, 0, camera.y + mapH - glowSize);
-      bottomGlow.addColorStop(0, "rgba(30, 80, 180, 0.15)");
-      bottomGlow.addColorStop(1, "rgba(30, 80, 180, 0)");
-      ctx.fillStyle = bottomGlow;
-      ctx.fillRect(camera.x, camera.y + mapH - glowSize, mapW, glowSize);
-
-      const leftGlow = ctx.createLinearGradient(camera.x, 0, camera.x + glowSize, 0);
-      leftGlow.addColorStop(0, "rgba(30, 80, 180, 0.12)");
-      leftGlow.addColorStop(1, "rgba(30, 80, 180, 0)");
-      ctx.fillStyle = leftGlow;
-      ctx.fillRect(camera.x, camera.y, glowSize, mapH);
-
-      const rightGlow = ctx.createLinearGradient(camera.x + mapW, 0, camera.x + mapW - glowSize, 0);
-      rightGlow.addColorStop(0, "rgba(30, 80, 180, 0.12)");
-      rightGlow.addColorStop(1, "rgba(30, 80, 180, 0)");
-      ctx.fillStyle = rightGlow;
-      ctx.fillRect(camera.x + mapW - glowSize, camera.y, glowSize, mapH);
-
-      const gridAlpha = Math.min(0.15, 0.05 + camera.zoom * 0.01);
+      // ── Lat/Lng grid lines using the orthographic projection ───────────────
+      const gridAlpha = Math.min(0.18, 0.06 + camera.zoom * 0.015);
       ctx.strokeStyle = `rgba(100, 200, 255, ${gridAlpha})`;
-      ctx.lineWidth = 0.5;
-      for (let latLine = -60; latLine <= 60; latLine += 30) {
-        const sy = ((90 - latLine) / 180) * mapH + camera.y;
-        if (sy >= -1 && sy <= h + 1) {
-          ctx.beginPath();
-          ctx.moveTo(Math.max(0, camera.x), sy);
-          ctx.lineTo(Math.min(w, camera.x + mapW), sy);
-          ctx.stroke();
+      ctx.lineWidth   = 0.5;
+
+      const drawGlobeGridLine = (pts: { lat: number; lng: number }[]) => {
+        let started = false;
+        ctx.beginPath();
+        for (const pt of pts) {
+          const s = latLngToScreen(pt.lat, pt.lng, w, h);
+          if (!s) { started = false; continue; }
+          if (!started) { ctx.moveTo(s.x, s.y); started = true; }
+          else            ctx.lineTo(s.x, s.y);
         }
+        ctx.stroke();
+      };
+
+      // Latitude parallels (every 30°)
+      for (let lat = -60; lat <= 60; lat += 30) {
+        const pts: { lat: number; lng: number }[] = [];
+        for (let lng = -180; lng <= 180; lng += 3) pts.push({ lat, lng });
+        drawGlobeGridLine(pts);
       }
-      for (let lngLine = -150; lngLine <= 150; lngLine += 30) {
-        const sx = ((lngLine + 180) / 360) * mapW + camera.x;
-        if (sx >= -1 && sx <= w + 1) {
-          ctx.beginPath();
-          ctx.moveTo(sx, Math.max(0, camera.y));
-          ctx.lineTo(sx, Math.min(h, camera.y + mapH));
-          ctx.stroke();
-        }
+      // Longitude meridians (every 30°)
+      for (let lng = -150; lng <= 180; lng += 30) {
+        const pts: { lat: number; lng: number }[] = [];
+        for (let lat = -90; lat <= 90; lat += 3) pts.push({ lat, lng });
+        drawGlobeGridLine(pts);
       }
 
-      const plotSize = getPlotSize(w);
+      // ── Plots ─────────────────────────────────────────────────────────────
+      const plotSize   = getPlotSize(w, h);
       const playerPulse = Math.sin(pulse * 2) * 0.15 + 0.85;
       pulse += 0.02;
 
       const selectedPlot = selectedParcelId ? plotIndex.get(selectedParcelId) : null;
 
       for (let i = 0; i < parcels.length; i++) {
-        const p = parcels[i];
-        const { x, y } = latLngToScreen(p.lat, p.lng, w, h);
-
-        if (x < -plotSize * 2 || x > w + plotSize * 2 || y < -plotSize * 2 || y > h + plotSize * 2) continue;
+        const p         = parcels[i];
+        const screenPos = latLngToScreen(p.lat, p.lng, w, h);
+        if (!screenPos) continue; // back hemisphere — not visible
+        const { x, y } = screenPos;
 
         const isPlayerOwned = p.ownerId && currentPlayerId && p.ownerId === currentPlayerId;
-        const isEnemyOwned = p.ownerId && !isPlayerOwned;
-        const isSelected = p.id === selectedParcelId;
-        const isHovered = p.id === hoveredPlotId;
+        const isEnemyOwned  = p.ownerId && !isPlayerOwned;
+        const isSelected    = p.id === selectedParcelId;
+        const isHovered     = p.id === hoveredPlotId;
 
-        let size = plotSize;
+        let size  = plotSize;
         if (isPlayerOwned) size = plotSize * 1.4;
         else if (isEnemyOwned) size = plotSize * 1.2;
 
         let color = COLORS.unclaimed;
         if (isSelected) {
           color = COLORS.selected;
-          size = plotSize * 1.8;
+          size  = plotSize * 1.8;
         } else if (isHovered) {
           color = isPlayerOwned ? COLORS.playerGlow : isEnemyOwned ? COLORS.enemyGlow : COLORS.hover;
-          size = plotSize * 1.5;
+          size  = plotSize * 1.5;
         } else if (isPlayerOwned) {
-          const r = parseInt(COLORS.player.slice(1, 3), 16);
-          const g = parseInt(COLORS.player.slice(3, 5), 16);
-          const b = parseInt(COLORS.player.slice(5, 7), 16);
+          const r  = parseInt(COLORS.player.slice(1, 3), 16);
+          const g  = parseInt(COLORS.player.slice(3, 5), 16);
+          const b  = parseInt(COLORS.player.slice(5, 7), 16);
           const pr = Math.min(255, Math.round(r * (playerPulse + 0.15)));
           const pg = Math.min(255, Math.round(g * (playerPulse + 0.15)));
           const pb = Math.min(255, Math.round(b * (playerPulse + 0.15)));
@@ -342,42 +384,51 @@ export function FlatMap({
 
         if (isPlayerOwned && !isSelected && !isHovered) {
           ctx.shadowColor = COLORS.playerGlow;
-          ctx.shadowBlur = plotSize * 0.8;
+          ctx.shadowBlur  = plotSize * 0.8;
         } else if (isSelected) {
           ctx.shadowColor = "#ffffff";
-          ctx.shadowBlur = plotSize * 1.5;
+          ctx.shadowBlur  = plotSize * 1.5;
         } else {
           ctx.shadowColor = "transparent";
-          ctx.shadowBlur = 0;
+          ctx.shadowBlur  = 0;
         }
 
         ctx.fillStyle = color;
         ctx.fillRect(x - size / 2, y - size / 2, size, size);
 
         ctx.shadowColor = "transparent";
-        ctx.shadowBlur = 0;
+        ctx.shadowBlur  = 0;
       }
 
+      // Selected plot rings
       if (selectedPlot) {
-        const { x, y } = latLngToScreen(selectedPlot.lat, selectedPlot.lng, w, h);
-        const ringSize = plotSize * 2.5;
-        ctx.strokeStyle = "#ffffff";
-        ctx.lineWidth = 1.5;
-        ctx.beginPath();
-        ctx.arc(x, y, ringSize, 0, Math.PI * 2);
-        ctx.stroke();
+        const screenPos = latLngToScreen(selectedPlot.lat, selectedPlot.lng, w, h);
+        if (screenPos) {
+          const { x, y } = screenPos;
+          const ringSize  = plotSize * 2.5;
+          ctx.strokeStyle = "#ffffff";
+          ctx.lineWidth   = 1.5;
+          ctx.beginPath();
+          ctx.arc(x, y, ringSize, 0, Math.PI * 2);
+          ctx.stroke();
 
-        ctx.strokeStyle = "rgba(255,255,255,0.3)";
-        ctx.lineWidth = 1;
-        ctx.beginPath();
-        ctx.arc(x, y, ringSize * 1.5, 0, Math.PI * 2);
-        ctx.stroke();
+          ctx.strokeStyle = "rgba(255,255,255,0.3)";
+          ctx.lineWidth   = 1;
+          ctx.beginPath();
+          ctx.arc(x, y, ringSize * 1.5, 0, Math.PI * 2);
+          ctx.stroke();
 
-        selectedScreenPosRef.current = { x, y };
-        const now = Date.now();
-        if (now - lastPosUpdateRef.current > 50) {
-          lastPosUpdateRef.current = now;
-          setSelectedScreenPos({ x, y });
+          selectedScreenPosRef.current = { x, y };
+          const now = Date.now();
+          if (now - lastPosUpdateRef.current > 50) {
+            lastPosUpdateRef.current = now;
+            setSelectedScreenPos({ x, y });
+          }
+        } else {
+          if (selectedScreenPosRef.current) {
+            selectedScreenPosRef.current = null;
+            setSelectedScreenPos(null);
+          }
         }
       } else {
         if (selectedScreenPosRef.current) {
@@ -386,35 +437,56 @@ export function FlatMap({
         }
       }
 
+      // ── Limb darkening — sphere shading applied on top of everything ───────
+      // Darkens the edges so the disc looks like a sphere rather than a flat circle.
+      const limbGrad = ctx.createRadialGradient(cx, cy, R * 0.55, cx, cy, R);
+      limbGrad.addColorStop(0,    "rgba(0,0,0,0)");
+      limbGrad.addColorStop(0.72, "rgba(0,0,10,0.08)");
+      limbGrad.addColorStop(0.88, "rgba(0,5,30,0.42)");
+      limbGrad.addColorStop(1.0,  "rgba(0,10,40,0.82)");
+      ctx.fillStyle = limbGrad;
+      ctx.fillRect(cx - R, cy - R, R * 2, R * 2);
+
+      ctx.restore(); // ← end globe clip
+
+      // ── Globe border ring ─────────────────────────────────────────────────
+      ctx.strokeStyle = "rgba(60, 140, 255, 0.55)";
+      ctx.lineWidth   = 1.5;
+      ctx.beginPath();
+      ctx.arc(cx, cy, R, 0, Math.PI * 2);
+      ctx.stroke();
+
       animFrameRef.current = requestAnimationFrame(render);
     };
 
     animFrameRef.current = requestAnimationFrame(render);
     return () => cancelAnimationFrame(animFrameRef.current);
-  }, [parcels, selectedParcelId, hoveredPlotId, currentPlayerId, camera, getPlotSize, latLngToScreen, plotIndex]);
+  }, [parcels, selectedParcelId, hoveredPlotId, currentPlayerId, camera, getPlotSize, getGlobeRadius, latLngToScreen, plotIndex]);
 
   const findPlotAt = useCallback(
     (clientX: number, clientY: number) => {
       const canvas = canvasRef.current;
       if (!canvas) return null;
-      const rect = canvas.getBoundingClientRect();
-      const sx = clientX - rect.left;
-      const sy = clientY - rect.top;
-      const w = rect.width;
-      const h = rect.height;
-      const plotSize = getPlotSize(w);
+      const rect      = canvas.getBoundingClientRect();
+      const sx        = clientX - rect.left;
+      const sy        = clientY - rect.top;
+      const w         = rect.width;
+      const h         = rect.height;
+      const plotSize  = getPlotSize(w, h);
       const hitRadius = Math.max(plotSize * 1.2, 8);
 
       let closest: LandParcel | null = null;
       let closestDist = Infinity;
 
       for (const p of parcels) {
-        const { x, y } = latLngToScreen(p.lat, p.lng, w, h);
-        const dx = sx - x;
-        const dy = sy - y;
+        const screenPos = latLngToScreen(p.lat, p.lng, w, h);
+        if (!screenPos) continue; // back hemisphere
+        const { x, y } = screenPos;
+        const dx   = sx - x;
+        const dy   = sy - y;
         const dist = dx * dx + dy * dy;
         if (dist < hitRadius * hitRadius && dist < closestDist) {
-          closest = p;
+          closest     = p;
           closestDist = dist;
         }
       }
@@ -425,7 +497,7 @@ export function FlatMap({
 
   const handlePointerDown = useCallback((e: React.PointerEvent) => {
     isDragging.current = false;
-    lastMouse.current = { x: e.clientX, y: e.clientY };
+    lastMouse.current  = { x: e.clientX, y: e.clientY };
     (e.target as HTMLElement).setPointerCapture(e.pointerId);
   }, []);
 
@@ -434,10 +506,21 @@ export function FlatMap({
       if (e.buttons > 0) {
         const dx = e.clientX - lastMouse.current.x;
         const dy = e.clientY - lastMouse.current.y;
-        if (Math.abs(dx) > 2 || Math.abs(dy) > 2) {
-          isDragging.current = true;
+        if (Math.abs(dx) > 2 || Math.abs(dy) > 2) isDragging.current = true;
+
+        // Convert pixel drag to globe rotation.
+        // degPerPx: at the equator, moving R pixels spans 180°.
+        const canvas = canvasRef.current;
+        if (canvas) {
+          const rect     = canvas.getBoundingClientRect();
+          const R        = Math.min(rect.width, rect.height) / 2 * cameraRef.current.zoom * 0.9;
+          const degPerPx = 180 / (Math.PI * R);
+          setCamera((prev) => ({
+            ...prev,
+            centerLng: ((prev.centerLng - dx * degPerPx) + 540) % 360 - 180,
+            centerLat: Math.max(-85, Math.min(85, prev.centerLat + dy * degPerPx)),
+          }));
         }
-        setCamera((prev) => ({ ...prev, x: prev.x + dx, y: prev.y + dy }));
         lastMouse.current = { x: e.clientX, y: e.clientY };
       } else {
         const plot = findPlotAt(e.clientX, e.clientY);
@@ -453,9 +536,7 @@ export function FlatMap({
     (e: React.PointerEvent) => {
       if (!isDragging.current) {
         const plot = findPlotAt(e.clientX, e.clientY);
-        if (plot) {
-          onParcelSelect(plot.id);
-        }
+        if (plot) onParcelSelect(plot.id);
       }
       isDragging.current = false;
     },
@@ -464,23 +545,11 @@ export function FlatMap({
 
   const handleWheel = useCallback((e: React.WheelEvent) => {
     e.preventDefault();
-    const canvas = canvasRef.current;
-    if (!canvas) return;
-    const rect = canvas.getBoundingClientRect();
-    const mx = e.clientX - rect.left;
-    const my = e.clientY - rect.top;
-
     const zoomFactor = e.deltaY < 0 ? 1.15 : 0.87;
-
-    setCamera((prev) => {
-      const newZoom = Math.max(0.5, Math.min(15, prev.zoom * zoomFactor));
-      const scale = newZoom / prev.zoom;
-      return {
-        zoom: newZoom,
-        x: mx - (mx - prev.x) * scale,
-        y: my - (my - prev.y) * scale,
-      };
-    });
+    setCamera((prev) => ({
+      ...prev,
+      zoom: Math.max(0.5, Math.min(8, prev.zoom * zoomFactor)),
+    }));
   }, []);
 
   const handleTouchStart = useCallback((e: React.TouchEvent) => {
@@ -493,40 +562,28 @@ export function FlatMap({
 
   const handleTouchMove = useCallback((e: React.TouchEvent) => {
     if (e.touches.length === 2) {
-      const dx = e.touches[0].clientX - e.touches[1].clientX;
-      const dy = e.touches[0].clientY - e.touches[1].clientY;
+      const dx   = e.touches[0].clientX - e.touches[1].clientX;
+      const dy   = e.touches[0].clientY - e.touches[1].clientY;
       const dist = Math.sqrt(dx * dx + dy * dy);
       if (lastPinchDist.current > 0) {
         const scale = dist / lastPinchDist.current;
         setCamera((prev) => ({
           ...prev,
-          zoom: Math.max(0.5, Math.min(15, prev.zoom * scale)),
+          zoom: Math.max(0.5, Math.min(8, prev.zoom * scale)),
         }));
       }
       lastPinchDist.current = dist;
     }
   }, []);
 
-  const centerOnPlot = useCallback(
-    (plot: LandParcel) => {
-      const canvas = canvasRef.current;
-      if (!canvas) return;
-      const rect = canvas.getBoundingClientRect();
-      const w = rect.width;
-      const h = rect.height;
-      const targetZoom = 5;
-      const mapW = w * targetZoom;
-      const mapH = h * targetZoom;
-      const px = ((plot.lng + 180) / 360) * mapW;
-      const py = ((90 - plot.lat) / 180) * mapH;
-      setCamera({
-        zoom: targetZoom,
-        x: w / 2 - px,
-        y: h / 2 - py,
-      });
-    },
-    []
-  );
+  // Rotate the globe so the given plot is centered on screen.
+  const centerOnPlot = useCallback((plot: LandParcel) => {
+    setCamera((prev) => ({
+      ...prev,
+      centerLat: plot.lat,
+      centerLng: plot.lng,
+    }));
+  }, []);
 
   const handleLocate = useCallback(() => {
     if (onLocateTerritory) onLocateTerritory();
@@ -541,20 +598,19 @@ export function FlatMap({
   }, [onFindEnemyTarget]);
 
   const handleResetView = useCallback(() => {
-    setCamera({ x: 0, y: 0, zoom: 1 });
+    setCamera({ centerLat: 0, centerLng: 0, zoom: 1 });
   }, []);
 
+  // Auto-rotate globe to bring a newly selected plot into view if it is on the back hemisphere.
   useEffect(() => {
     if (selectedParcelId) {
       const plot = plotIndex.get(selectedParcelId);
       if (plot) {
         const canvas = canvasRef.current;
         if (canvas) {
-          const rect = canvas.getBoundingClientRect();
-          const { x, y } = latLngToScreen(plot.lat, plot.lng, rect.width, rect.height);
-          if (x < 0 || x > rect.width || y < 0 || y > rect.height) {
-            centerOnPlot(plot);
-          }
+          const rect      = canvas.getBoundingClientRect();
+          const screenPos = latLngToScreen(plot.lat, plot.lng, rect.width, rect.height);
+          if (!screenPos) centerOnPlot(plot);
         }
       }
     }
@@ -583,18 +639,18 @@ export function FlatMap({
         const popupH = 140;
         let px = selectedScreenPos.x + 20;
         let py = selectedScreenPos.y - popupH / 2;
-        if (px + popupW > containerRect.width - 10) px = selectedScreenPos.x - popupW - 20;
-        if (py < 10) py = 10;
-        if (py + popupH > containerRect.height - 10) py = containerRect.height - popupH - 10;
-        const sectorKey = getSector(plot.lat, plot.lng);
+        if (px + popupW > containerRect.width  - 10) px = selectedScreenPos.x - popupW - 20;
+        if (py < 10)                                  py = 10;
+        if (py + popupH > containerRect.height - 10)  py = containerRect.height - popupH - 10;
+        const sectorKey  = getSector(plot.lat, plot.lng);
         const sectorName = SECTOR_NAMES[sectorKey] || "Unknown Sector";
-        const plotName = getPlotName(plot.plotId, plot.biome as BiomeType);
-        const ownerName = plot.ownerId ? (playerMap.get(plot.ownerId) || "Unknown") : "Unclaimed";
-        const isPlayer = plot.ownerId === currentPlayerId;
-        const isEnemy = plot.ownerId && !isPlayer;
+        const plotName   = getPlotName(plot.plotId, plot.biome as BiomeType);
+        const ownerName  = plot.ownerId ? (playerMap.get(plot.ownerId) || "Unknown") : "Unclaimed";
+        const isPlayer   = plot.ownerId === currentPlayerId;
+        const isEnemy    = plot.ownerId && !isPlayer;
         const statusColor = isPlayer ? "#00ff44" : isEnemy ? "#ff2222" : "#888";
-        const statusText = isPlayer ? "YOUR BASE" : isEnemy ? "HOSTILE" : "UNCLAIMED";
-        const biomeColor = biomeColors[plot.biome as BiomeType] || "#666";
+        const statusText  = isPlayer ? "YOUR BASE" : isEnemy ? "HOSTILE" : "UNCLAIMED";
+        const biomeColor  = biomeColors[plot.biome as BiomeType] || "#666";
 
         return (
           <div


### PR DESCRIPTION
Switch the 2D canvas map from a flat pan/zoom Mercator layout to an
orthographic globe projection so the map looks like a sphere:

- latLngToScreen now uses the orthographic formula centred on
  camera.centerLat/centerLng and returns null for back-hemisphere points
  (back-face culling — those plots are simply skipped)
- screenToLatLng updated with the inverse orthographic formula
- Camera state changed from {x,y,zoom} to {centerLat,centerLng,zoom};
  dragging now rotates the globe instead of panning
- Lat/lng grid lines are redrawn as curved arcs via the new projection
- Map image and all plots are clipped to a circle via canvas clip()
- Limb darkening: radial gradient darkens the disc edges like a real sphere
- Atmosphere glow: soft blue radial halo rendered just outside the globe rim
- Globe border ring drawn after the clip region
- centerOnPlot now rotates to the plot's lat/lng rather than panning
- cameraRef added so pointer-move handler always reads current zoom without
  stale closure

https://claude.ai/code/session_018DeHMjsdJ5TcX3GxkxmreF