### PR TITLE
fix: resolve blockchain not-initialized error on startup

### DIFF
--- a/server/algorand.ts
+++ b/server/algorand.ts
@@ -29,7 +29,11 @@ export function getAdminAccount(): algosdk.Account {
 }
 
 export function getAdminAddress(): string {
-  return getAdminAccount().addr.toString();
+  try {
+    return getAdminAccount().addr.toString();
+  } catch {
+    return process.env.ALGORAND_ADMIN_ADDRESS || "";
+  }
 }
 
 export function getFrontierAsaId(): number | null {

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -12,8 +12,11 @@ export async function registerRoutes(
 
   let blockchainReady = false;
   initializeBlockchain().then((result) => {
-    blockchainReady = true;
+    blockchainReady = result.asaId !== null;
     console.log(`Blockchain initialized: ASA=${result.asaId}, Admin=${result.adminAddress}, ALGO=${result.adminAlgo}`);
+    if (!blockchainReady) {
+      console.warn("Blockchain initialization incomplete: ASA not created (check ALGO balance and env vars).");
+    }
   }).catch((err) => {
     console.error("Blockchain init failed:", err);
   });


### PR DESCRIPTION
Two bugs caused the "blockchain not initialized yet" toast to persist:

1. getAdminAddress() called getAdminAccount() which throws if
   ALGORAND_ADMIN_MNEMONIC is unset. The /api/blockchain/status
   catch-block then returned adminAddress: null to the client,
   triggering the error. Fixed by catching the throw and falling
   back to the ALGORAND_ADMIN_ADDRESS env var.

2. blockchainReady was set to true even when initializeBlockchain()
   returned asaId: null (e.g. low ALGO balance). Fixed by gating
   the flag on result.asaId !== null so the status endpoint
   accurately reflects whether the ASA is actually ready.

https://claude.ai/code/session_0135PbxkjMQeVUKMK9hjMBez