### PR TITLE
feat: add orbital satellite deployment system

### DIFF
--- a/client/src/components/game/CommanderPanel.tsx
+++ b/client/src/components/game/CommanderPanel.tsx
@@ -1,12 +1,12 @@
 import { useState } from "react";
-import { Shield, Swords, Zap, Target, Radio, Crosshair, Skull, Radar, Clock } from "lucide-react";
+import { Shield, Swords, Zap, Target, Radio, Crosshair, Skull, Radar, Clock, Satellite } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Card } from "@/components/ui/card";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { cn } from "@/lib/utils";
 import type { Player, CommanderTier, SpecialAttackType } from "@shared/schema";
-import { COMMANDER_INFO, SPECIAL_ATTACK_INFO, DRONE_MINT_COST_FRONTIER, MAX_DRONES, DRONE_SCOUT_DURATION_MS } from "@shared/schema";
+import { COMMANDER_INFO, SPECIAL_ATTACK_INFO, DRONE_MINT_COST_FRONTIER, MAX_DRONES, DRONE_SCOUT_DURATION_MS, SATELLITE_DEPLOY_COST_FRONTIER, MAX_SATELLITES, SATELLITE_ORBIT_DURATION_MS, SATELLITE_YIELD_BONUS } from "@shared/schema";
 import sentinelImg from "@assets/image_1771570491560.png";
 import phantomImg from "@assets/image_1771570495782.png";
 import reaperImg from "@assets/image_1771570500912.png";
@@ -35,10 +35,58 @@ interface CommanderPanelProps {
   player: Player | null;
   onMintAvatar: (tier: CommanderTier) => void;
   onDeployDrone: (targetParcelId?: string) => void;
+  onDeploySatellite: () => void;
   onSwitchCommander?: (index: number) => void;
   isMinting: boolean;
   isDeployingDrone: boolean;
+  isDeployingSatellite: boolean;
   className?: string;
+}
+
+function SatelliteCard({ satellite, index }: { satellite: Player["satellites"][0]; index: number }) {
+  const now = Date.now();
+  const remaining = Math.max(0, satellite.expiresAt - now);
+  const elapsed = now - satellite.deployedAt;
+  const progressPct = satellite.status === "active" ? Math.min(100, (elapsed / SATELLITE_ORBIT_DURATION_MS) * 100) : 100;
+
+  const formatTime = (ms: number) => {
+    const totalSec = Math.floor(ms / 1000);
+    const h = Math.floor(totalSec / 3600);
+    const m = Math.floor((totalSec % 3600) / 60);
+    const s = totalSec % 60;
+    if (h > 0) return `${h}h ${m}m`;
+    if (m > 0) return `${m}m ${s}s`;
+    return `${s}s`;
+  };
+
+  const isExpired = satellite.status === "expired" || remaining === 0;
+
+  return (
+    <Card className={cn("p-2 border text-xs", isExpired ? "border-muted opacity-60" : "border-yellow-500/50 bg-yellow-500/5")}>
+      <div className="flex items-center justify-between mb-1">
+        <span className="font-display uppercase tracking-wide text-[10px]">
+          SAT-{String(index + 1).padStart(2, "0")}
+        </span>
+        <Badge variant={isExpired ? "secondary" : "default"} className="text-[9px] px-1 py-0">
+          {isExpired ? "expired" : "orbiting"}
+        </Badge>
+      </div>
+      {!isExpired && (
+        <>
+          <div className="w-full bg-muted rounded-full h-1 mb-1">
+            <div
+              className="h-1 rounded-full bg-yellow-500 transition-all"
+              style={{ width: `${progressPct}%` }}
+            />
+          </div>
+          <div className="flex items-center gap-1 text-muted-foreground">
+            <Clock className="w-2.5 h-2.5" />
+            <span>{formatTime(remaining)} remaining</span>
+          </div>
+        </>
+      )}
+    </Card>
+  );
 }
 
 function DroneCard({ drone, index }: { drone: Player["drones"][0]; index: number }) {
@@ -83,7 +131,7 @@ function DroneCard({ drone, index }: { drone: Player["drones"][0]; index: number
   );
 }
 
-export function CommanderPanel({ player, onMintAvatar, onDeployDrone, onSwitchCommander, isMinting, isDeployingDrone, className }: CommanderPanelProps) {
+export function CommanderPanel({ player, onMintAvatar, onDeployDrone, onDeploySatellite, onSwitchCommander, isMinting, isDeployingDrone, isDeployingSatellite, className }: CommanderPanelProps) {
   const [selectedTier, setSelectedTier] = useState<CommanderTier>("sentinel");
   const [showMintSection, setShowMintSection] = useState(false);
 
@@ -103,6 +151,8 @@ export function CommanderPanel({ player, onMintAvatar, onDeployDrone, onSwitchCo
     if (d.status !== "scouting") return true;
     return Date.now() - d.deployedAt < DRONE_SCOUT_DURATION_MS + 300000;
   });
+  const now = Date.now();
+  const activeSatellites = (player.satellites ?? []).filter(s => s.status === "active" && s.expiresAt > now);
 
   return (
     <div className={cn("flex flex-col h-full", className)} data-testid="commander-panel">
@@ -345,6 +395,44 @@ export function CommanderPanel({ player, onMintAvatar, onDeployDrone, onSwitchCo
               <div className="text-center py-4 text-muted-foreground">
                 <Radar className="w-6 h-6 mx-auto mb-1 opacity-30" />
                 <p className="text-[10px]">No drones deployed</p>
+              </div>
+            )}
+          </div>
+
+          <div data-testid="satellite-section">
+            <h3 className="text-xs font-display uppercase tracking-wide text-muted-foreground mb-2 flex items-center gap-1.5">
+              <Satellite className="w-3.5 h-3.5" /> Orbital Satellites ({activeSatellites.length}/{MAX_SATELLITES})
+            </h3>
+            <div className="flex items-center gap-2 mb-3">
+              <div className="w-10 h-10 rounded-md bg-yellow-500/10 border border-yellow-500/30 flex items-center justify-center shrink-0">
+                <Satellite className="w-5 h-5 text-yellow-400" />
+              </div>
+              <div className="flex-1 min-w-0">
+                <span className="text-[10px] text-muted-foreground block">
+                  +{SATELLITE_YIELD_BONUS * 100}% mining yield on all owned plots for 1 hour. Cost: {SATELLITE_DEPLOY_COST_FRONTIER} FRNTR.
+                </span>
+              </div>
+              <Button
+                size="sm"
+                onClick={() => onDeploySatellite()}
+                disabled={isDeployingSatellite || activeSatellites.length >= MAX_SATELLITES || player.frontier < SATELLITE_DEPLOY_COST_FRONTIER}
+                className="font-display uppercase tracking-wide text-xs shrink-0"
+                data-testid="button-deploy-satellite"
+              >
+                <Satellite className="w-3.5 h-3.5 mr-1" />
+                {isDeployingSatellite ? "..." : "Launch"}
+              </Button>
+            </div>
+            {activeSatellites.length > 0 ? (
+              <div className="space-y-2">
+                {activeSatellites.map((sat, i) => (
+                  <SatelliteCard key={sat.id} satellite={sat} index={i} />
+                ))}
+              </div>
+            ) : (
+              <div className="text-center py-4 text-muted-foreground">
+                <Satellite className="w-6 h-6 mx-auto mb-1 opacity-30" />
+                <p className="text-[10px]">No satellites in orbit</p>
               </div>
             )}
           </div>

--- a/client/src/components/game/GameLayout.tsx
+++ b/client/src/components/game/GameLayout.tsx
@@ -16,7 +16,7 @@ import { WarRoomPanel } from "./WarRoomPanel";
 import { WalletConnect } from "./WalletConnect";
 import { useWallet } from "@/hooks/useWallet";
 import { useBlockchainActions } from "@/hooks/useBlockchainActions";
-import { useGameState, useCurrentPlayer, useMine, useUpgrade, useAttack, useBuild, usePurchase, useCollectAll, useClaimFrontier, useMintAvatar, useSwitchCommander, useSpecialAttack, useDeployDrone } from "@/hooks/useGameState";
+import { useGameState, useCurrentPlayer, useMine, useUpgrade, useAttack, useBuild, usePurchase, useCollectAll, useClaimFrontier, useMintAvatar, useSwitchCommander, useSpecialAttack, useDeployDrone, useDeploySatellite } from "@/hooks/useGameState";
 import { useToast } from "@/hooks/use-toast";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Button } from "@/components/ui/button";
@@ -39,6 +39,7 @@ export function GameLayout() {
     queueSpecialAttackAction,
     queueSwitchCommanderAction,
     queueDeployDroneAction,
+    queueDeploySatelliteAction,
     isWalletConnected,
     frontierAsaId,
     isOptedInToFrontier,
@@ -71,6 +72,7 @@ export function GameLayout() {
   const specialAttackMutation = useSpecialAttack();
   const switchCommanderMutation = useSwitchCommander();
   const deployDroneMutation = useDeployDrone();
+  const deploySatelliteMutation = useDeploySatellite();
 
   useEffect(() => {
     const seen = localStorage.getItem("frontier_onboarding_done");
@@ -270,6 +272,18 @@ export function GameLayout() {
       {
         onSuccess: () => toast({ title: "Drone Deployed", description: "Recon Drone is now scouting enemy territory." }),
         onError: (error) => toast({ title: "Deploy Failed", description: error.message, variant: "destructive" }),
+      }
+    );
+  };
+
+  const handleDeploySatellite = () => {
+    if (!player) return;
+    queueDeploySatelliteAction();
+    deploySatelliteMutation.mutate(
+      { playerId: player.id },
+      {
+        onSuccess: () => toast({ title: "Satellite Launched", description: "+25% mining yield on all your territories for 1 hour." }),
+        onError: (error) => toast({ title: "Launch Failed", description: error.message, variant: "destructive" }),
       }
     );
   };
@@ -493,9 +507,11 @@ export function GameLayout() {
               player={player}
               onMintAvatar={handleMintAvatar}
               onDeployDrone={handleDeployDrone}
+              onDeploySatellite={handleDeploySatellite}
               onSwitchCommander={handleSwitchCommander}
               isMinting={mintAvatarMutation.isPending}
               isDeployingDrone={deployDroneMutation.isPending}
+              isDeployingSatellite={deploySatelliteMutation.isPending}
             />
           )}
           {activeTab === "leaderboard" && gameState && (

--- a/client/src/hooks/useBlockchainActions.ts
+++ b/client/src/hooks/useBlockchainActions.ts
@@ -27,6 +27,7 @@ type ActionType =
   | "mint_avatar"
   | "special_attack"
   | "deploy_drone"
+  | "deploy_satellite"
   | "switch_commander";
 
 export function useBlockchainActions() {
@@ -156,6 +157,14 @@ export function useBlockchainActions() {
     (targetPlotId?: number) => {
       if (isConnected && address)
         enqueueGameAction("deploy_drone", targetPlotId ?? 0);
+    },
+    [isConnected, address]
+  );
+
+  const queueDeploySatelliteAction = useCallback(
+    () => {
+      if (isConnected && address)
+        enqueueGameAction("deploy_satellite", 0);
     },
     [isConnected, address]
   );
@@ -374,6 +383,7 @@ export function useBlockchainActions() {
     queueSpecialAttackAction,
     queueSwitchCommanderAction,
     queueDeployDroneAction,
+    queueDeploySatelliteAction,
     isWalletConnected: isConnected,
     frontierAsaId,
     isOptedInToFrontier: isOptedIn,

--- a/client/src/hooks/useGameState.ts
+++ b/client/src/hooks/useGameState.ts
@@ -1,6 +1,6 @@
 import { useQuery, useMutation } from "@tanstack/react-query";
 import { queryClient, apiRequest } from "@/lib/queryClient";
-import type { GameState, MineAction, UpgradeAction, AttackAction, BuildAction, PurchaseAction, MintAvatarAction, SpecialAttackAction, DeployDroneAction } from "@shared/schema";
+import type { GameState, MineAction, UpgradeAction, AttackAction, BuildAction, PurchaseAction, MintAvatarAction, SpecialAttackAction, DeployDroneAction, DeploySatelliteAction } from "@shared/schema";
 
 export function useGameState() {
   return useQuery<GameState>({
@@ -151,6 +151,18 @@ export function useDeployDrone() {
   return useMutation({
     mutationFn: async (action: DeployDroneAction) => {
       const response = await apiRequest("POST", "/api/actions/deploy-drone", action);
+      return response.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["/api/game/state"] });
+    },
+  });
+}
+
+export function useDeploySatellite() {
+  return useMutation({
+    mutationFn: async (action: DeploySatelliteAction) => {
+      const response = await apiRequest("POST", "/api/actions/deploy-satellite", action);
       return response.json();
     },
     onSuccess: () => {

--- a/server/db-schema.ts
+++ b/server/db-schema.ts
@@ -55,6 +55,7 @@ export const players = pgTable("players", {
   activeCommanderIndex: integer("active_commander_index").notNull().default(0),
   specialAttacks:       jsonb("special_attacks").$type<object[]>().notNull().default([]),
   drones:               jsonb("drones").$type<object[]>().notNull().default([]),
+  satellites:           jsonb("satellites").$type<object[]>().notNull().default([]),
   welcomeBonusReceived: boolean("welcome_bonus_received").notNull().default(false),
 });
 

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1,7 +1,7 @@
 import type { Express } from "express";
 import { createServer, type Server } from "http";
 import { storage } from "./storage";
-import { mineActionSchema, upgradeActionSchema, attackActionSchema, buildActionSchema, purchaseActionSchema, collectActionSchema, claimFrontierActionSchema, mintAvatarActionSchema, specialAttackActionSchema, deployDroneActionSchema } from "@shared/schema";
+import { mineActionSchema, upgradeActionSchema, attackActionSchema, buildActionSchema, purchaseActionSchema, collectActionSchema, claimFrontierActionSchema, mintAvatarActionSchema, specialAttackActionSchema, deployDroneActionSchema, deploySatelliteActionSchema } from "@shared/schema";
 import { z } from "zod";
 import { initializeBlockchain, getFrontierAsaId, getAdminAddress, getAdminBalance, transferFrontierASA, isAddressOptedInToFrontier, batchedTransferFrontierASA } from "./algorand";
 
@@ -331,6 +331,17 @@ export async function registerRoutes(
     } catch (error) {
       if (error instanceof z.ZodError) return res.status(400).json({ error: "Invalid request data" });
       res.status(400).json({ error: error instanceof Error ? error.message : "Drone deployment failed" });
+    }
+  });
+
+  app.post("/api/actions/deploy-satellite", async (req, res) => {
+    try {
+      const action = deploySatelliteActionSchema.parse(req.body);
+      const satellite = await storage.deploySatellite(action);
+      res.json({ success: true, satellite });
+    } catch (error) {
+      if (error instanceof z.ZodError) return res.status(400).json({ error: "Invalid request data" });
+      res.status(400).json({ error: error instanceof Error ? error.message : "Satellite deployment failed" });
     }
   });
 

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -17,8 +17,10 @@ import type {
   MintAvatarAction,
   SpecialAttackAction,
   DeployDroneAction,
+  DeploySatelliteAction,
   CommanderAvatar,
   ReconDrone,
+  OrbitalSatellite,
   SpecialAttackRecord,
   CommanderTier,
   SpecialAttackType,
@@ -43,6 +45,10 @@ import {
   DRONE_MINT_COST_FRONTIER,
   DRONE_SCOUT_DURATION_MS,
   MAX_DRONES,
+  SATELLITE_DEPLOY_COST_FRONTIER,
+  SATELLITE_ORBIT_DURATION_MS,
+  MAX_SATELLITES,
+  SATELLITE_YIELD_BONUS,
   calculateFrontierPerDay,
 } from "@shared/schema";
 import type { FacilityType, DefenseImprovementType } from "@shared/schema";
@@ -94,6 +100,7 @@ export interface IStorage {
   mintAvatar(action: MintAvatarAction): Promise<CommanderAvatar>;
   executeSpecialAttack(action: SpecialAttackAction): Promise<{ damage: number; effect: string }>;
   deployDrone(action: DeployDroneAction): Promise<ReconDrone>;
+  deploySatellite(action: DeploySatelliteAction): Promise<OrbitalSatellite>;
   /** Grant the 500 FRONTIER welcome bonus (idempotent). */
   grantWelcomeBonus(playerId: string): Promise<void>;
   /**
@@ -189,6 +196,7 @@ export class MemStorage implements IStorage {
       activeCommanderIndex: 0,
       specialAttacks: [],
       drones: [],
+      satellites: [],
       welcomeBonusReceived: false,
     };
     this.players.set(humanPlayerId, humanPlayer);
@@ -232,6 +240,7 @@ export class MemStorage implements IStorage {
         activeCommanderIndex: 0,
         specialAttacks: [],
         drones: [],
+        satellites: [],
         welcomeBonusReceived: true,
       };
       this.players.set(aiId, aiPlayer);
@@ -341,11 +350,14 @@ export class MemStorage implements IStorage {
     const now = Date.now();
     if (now - parcel.lastMineTs < MINE_COOLDOWN_MS) throw new Error("Mining cooldown not complete");
 
+    const activeSatellites = player.satellites.filter(s => s.status === "active" && s.expiresAt > now);
+    const satelliteMult = activeSatellites.length > 0 ? 1 + SATELLITE_YIELD_BONUS : 1;
+
     const biomeBonus = biomeBonuses[parcel.biome];
     const richnessMultiplier = parcel.richness / 100;
-    const ironYield = Math.floor(BASE_YIELD.iron * biomeBonus.yieldMod * richnessMultiplier * parcel.yieldMultiplier);
-    const fuelYield = Math.floor(BASE_YIELD.fuel * biomeBonus.yieldMod * richnessMultiplier * parcel.yieldMultiplier);
-    const crystalYield = Math.floor(BASE_YIELD.crystal * richnessMultiplier);
+    const ironYield = Math.floor(BASE_YIELD.iron * biomeBonus.yieldMod * richnessMultiplier * parcel.yieldMultiplier * satelliteMult);
+    const fuelYield = Math.floor(BASE_YIELD.fuel * biomeBonus.yieldMod * richnessMultiplier * parcel.yieldMultiplier * satelliteMult);
+    const crystalYield = Math.floor(BASE_YIELD.crystal * richnessMultiplier * satelliteMult);
 
     const totalStored = parcel.ironStored + parcel.fuelStored + parcel.crystalStored;
     const remaining = parcel.storageCapacity - totalStored;
@@ -886,6 +898,47 @@ export class MemStorage implements IStorage {
     return drone;
   }
 
+  async deploySatellite(action: DeploySatelliteAction): Promise<OrbitalSatellite> {
+    await this.initialize();
+    const player = this.players.get(action.playerId);
+    if (!player) throw new Error("Player not found");
+
+    const now = Date.now();
+    // Expire stale satellites first
+    player.satellites = player.satellites.map(s =>
+      s.status === "active" && s.expiresAt <= now ? { ...s, status: "expired" as const } : s
+    );
+    const activeSatellites = player.satellites.filter(s => s.status === "active");
+    if (activeSatellites.length >= MAX_SATELLITES) throw new Error(`Maximum ${MAX_SATELLITES} active satellites allowed`);
+    if (player.frontier < SATELLITE_DEPLOY_COST_FRONTIER) {
+      throw new Error(`Insufficient FRONTIER. Need ${SATELLITE_DEPLOY_COST_FRONTIER}, have ${player.frontier.toFixed(2)}`);
+    }
+
+    player.frontier -= SATELLITE_DEPLOY_COST_FRONTIER;
+    player.totalFrontierBurned += SATELLITE_DEPLOY_COST_FRONTIER;
+    this.frontierCirculating -= SATELLITE_DEPLOY_COST_FRONTIER;
+
+    const satellite: OrbitalSatellite = {
+      id: randomUUID(),
+      deployedAt: now,
+      expiresAt: now + SATELLITE_ORBIT_DURATION_MS,
+      status: "active",
+    };
+
+    player.satellites.push(satellite);
+
+    this.events.push({
+      id: randomUUID(),
+      type: "deploy_satellite",
+      playerId: player.id,
+      description: `${player.name} launched an Orbital Satellite — +${SATELLITE_YIELD_BONUS * 100}% mining yield for 1 hour`,
+      timestamp: now,
+    });
+
+    this.lastUpdateTs = now;
+    return satellite;
+  }
+
   async resolveBattles(): Promise<Battle[]> {
     const now = Date.now();
     const resolvedBattles: Battle[] = [];
@@ -1163,6 +1216,7 @@ function rowToPlayer(row: PlayerRow, ownedParcelIds: string[]): Player {
     commander:            commanders[row.activeCommanderIndex] ?? null,
     specialAttacks:       (row.specialAttacks ?? []) as SpecialAttackRecord[],
     drones:               (row.drones ?? []) as ReconDrone[],
+    satellites:           (row.satellites ?? []) as OrbitalSatellite[],
     welcomeBonusReceived: row.welcomeBonusReceived,
   };
 }
@@ -1500,11 +1554,15 @@ export class DbStorage implements IStorage {
       const now = Date.now();
       if (now - parcel.lastMineTs < MINE_COOLDOWN_MS) throw new Error("Mining cooldown not complete");
 
+      const playerSatellites = (playerRow.satellites ?? []) as OrbitalSatellite[];
+      const activeSatellites = playerSatellites.filter(s => s.status === "active" && s.expiresAt > now);
+      const satelliteMult = activeSatellites.length > 0 ? 1 + SATELLITE_YIELD_BONUS : 1;
+
       const biomeBonus  = biomeBonuses[parcel.biome];
       const richMult    = parcel.richness / 100;
-      const ironYield   = Math.floor(BASE_YIELD.iron   * biomeBonus.yieldMod * richMult * parcel.yieldMultiplier);
-      const fuelYield   = Math.floor(BASE_YIELD.fuel   * biomeBonus.yieldMod * richMult * parcel.yieldMultiplier);
-      const crystalYield= Math.floor(BASE_YIELD.crystal * richMult);
+      const ironYield   = Math.floor(BASE_YIELD.iron   * biomeBonus.yieldMod * richMult * parcel.yieldMultiplier * satelliteMult);
+      const fuelYield   = Math.floor(BASE_YIELD.fuel   * biomeBonus.yieldMod * richMult * parcel.yieldMultiplier * satelliteMult);
+      const crystalYield= Math.floor(BASE_YIELD.crystal * richMult * satelliteMult);
 
       const totalStored = parcel.ironStored + parcel.fuelStored + parcel.crystalStored;
       const remaining   = parcel.storageCapacity - totalStored;
@@ -2131,6 +2189,49 @@ export class DbStorage implements IStorage {
       await this.bumpLastTs(now, tx);
 
       return drone;
+    });
+  }
+
+  async deploySatellite(action: DeploySatelliteAction): Promise<OrbitalSatellite> {
+    await this.initialize();
+    return this.db.transaction(async (tx) => {
+      const [row] = await tx.select().from(playersTable).where(eq(playersTable.id, action.playerId));
+      if (!row) throw new Error("Player not found");
+
+      const now = Date.now();
+      const satellites = ((row.satellites ?? []) as OrbitalSatellite[]).map(s =>
+        s.status === "active" && s.expiresAt <= now ? { ...s, status: "expired" as const } : s
+      );
+      const activeSatellites = satellites.filter(s => s.status === "active");
+      if (activeSatellites.length >= MAX_SATELLITES)
+        throw new Error(`Maximum ${MAX_SATELLITES} active satellites allowed`);
+      if (row.frontier < SATELLITE_DEPLOY_COST_FRONTIER)
+        throw new Error(`Insufficient FRONTIER. Need ${SATELLITE_DEPLOY_COST_FRONTIER}, have ${row.frontier.toFixed(2)}`);
+
+      const satellite: OrbitalSatellite = {
+        id:          randomUUID(),
+        deployedAt:  now,
+        expiresAt:   now + SATELLITE_ORBIT_DURATION_MS,
+        status:      "active",
+      };
+
+      await tx.update(playersTable)
+        .set({
+          frontier:            row.frontier            - SATELLITE_DEPLOY_COST_FRONTIER,
+          totalFrontierBurned: row.totalFrontierBurned + SATELLITE_DEPLOY_COST_FRONTIER,
+          satellites:          [...satellites, satellite],
+        })
+        .where(eq(playersTable.id, action.playerId));
+
+      await this.addEvent({
+        type:        "deploy_satellite",
+        playerId:    action.playerId,
+        description: `${row.name} launched an Orbital Satellite — +${SATELLITE_YIELD_BONUS * 100}% mining yield for 1 hour`,
+        timestamp:   now,
+      }, tx);
+      await this.bumpLastTs(now, tx);
+
+      return satellite;
     });
   }
 

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -155,6 +155,7 @@ export interface Player {
   activeCommanderIndex: number;
   specialAttacks: SpecialAttackRecord[];
   drones: ReconDrone[];
+  satellites: OrbitalSatellite[];
   welcomeBonusReceived: boolean;
 }
 
@@ -176,7 +177,7 @@ export interface Battle {
 
 export interface GameEvent {
   id: string;
-  type: "mine" | "upgrade" | "attack" | "battle_resolved" | "ai_action" | "purchase" | "build" | "claim_frontier" | "mint_avatar" | "special_attack" | "deploy_drone";
+  type: "mine" | "upgrade" | "attack" | "battle_resolved" | "ai_action" | "purchase" | "build" | "claim_frontier" | "mint_avatar" | "special_attack" | "deploy_drone" | "deploy_satellite";
   playerId: string;
   parcelId?: string;
   battleId?: string;
@@ -405,6 +406,18 @@ export const DRONE_MINT_COST_FRONTIER = 20;
 export const DRONE_SCOUT_DURATION_MS = 15 * 60 * 1000;
 export const MAX_DRONES = 5;
 
+export interface OrbitalSatellite {
+  id: string;
+  deployedAt: number;
+  expiresAt: number;
+  status: "active" | "expired";
+}
+
+export const SATELLITE_DEPLOY_COST_FRONTIER = 50;
+export const SATELLITE_ORBIT_DURATION_MS = 60 * 60 * 1000; // 1 hour
+export const MAX_SATELLITES = 2;
+export const SATELLITE_YIELD_BONUS = 0.25; // +25% mining yield
+
 export const mintAvatarActionSchema = z.object({
   playerId: z.string(),
   tier: z.enum(["sentinel", "phantom", "reaper"]),
@@ -421,9 +434,14 @@ export const deployDroneActionSchema = z.object({
   targetParcelId: z.string().optional(),
 });
 
+export const deploySatelliteActionSchema = z.object({
+  playerId: z.string(),
+});
+
 export type MintAvatarAction = z.infer<typeof mintAvatarActionSchema>;
 export type SpecialAttackAction = z.infer<typeof specialAttackActionSchema>;
 export type DeployDroneAction = z.infer<typeof deployDroneActionSchema>;
+export type DeploySatelliteAction = z.infer<typeof deploySatelliteActionSchema>;
 
 export function calculateFrontierPerDay(improvements: Improvement[]): number {
   let perDay = 1;


### PR DESCRIPTION
Introduces OrbitalSatellite — a strategic, time-limited asset that grants
+25% mining yield across all owned territories for 1 hour.

Changes:
- shared/schema.ts: OrbitalSatellite interface, constants
  (SATELLITE_DEPLOY_COST_FRONTIER=50, SATELLITE_ORBIT_DURATION_MS=1h,
  MAX_SATELLITES=2, SATELLITE_YIELD_BONUS=0.25), deploySatelliteActionSchema,
  DeploySatelliteAction type, and 'deploy_satellite' GameEvent type.
- server/db-schema.ts: satellites JSONB column on players table.
- server/storage.ts: deploySatellite() in IStorage, MemStorage and
  DbStorage; satellite yield multiplier applied in mineResources for
  both storage backends.
- server/routes.ts: POST /api/actions/deploy-satellite endpoint.
- client hooks: useDeploySatellite mutation, queueDeploySatelliteAction
  blockchain queue action.
- CommanderPanel: SatelliteCard component and satellite section with
  Launch button, orbit progress bar and countdown timer.
- GameLayout: handleDeploySatellite wired up end-to-end.

https://claude.ai/code/session_019CtJqmynH4sDKbs4mmw2k2