### PR TITLE
fix: add vite-plugin-node-polyfills to fix Replit build error

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,18 @@
 // vite.config.ts — clean version
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
+import { nodePolyfills } from "vite-plugin-node-polyfills";
 import path from "path";
 
 export default defineConfig({
-  plugins: [react()],
+  plugins: [
+    react(),
+    nodePolyfills({
+      // algosdk, @perawallet/connect, and lute-connect all need these
+      include: ["buffer", "crypto", "stream", "events", "util", "process"],
+      globals: { Buffer: true, global: true, process: true },
+    }),
+  ],
   resolve: {
     alias: {
       "@": path.resolve(import.meta.dirname, "client", "src"),


### PR DESCRIPTION
algosdk, @perawallet/connect, and lute-connect use Node.js built-ins
(crypto, buffer, stream, events) that Vite does not polyfill by default
in browser builds. The vite-plugin-node-polyfills package was already
present in dependencies but was never wired into vite.config.ts, causing
the client build step to crash during Replit deployment.

https://claude.ai/code/session_01Te9jQAjT8pPphTUpC7cmWX