### PR TITLE
Fix wallet data isolation: each address now gets its own player record

### DIFF
--- a/client/src/components/game/GameLayout.tsx
+++ b/client/src/components/game/GameLayout.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { TopBar } from "./TopBar";
 import { ResourceHUD } from "./ResourceHUD";
 import { FlatMap } from "./FlatMap";
@@ -18,6 +18,7 @@ import { useWallet } from "@/hooks/useWallet";
 import { useBlockchainActions } from "@/hooks/useBlockchainActions";
 import { useGameState, useCurrentPlayer, useMine, useUpgrade, useAttack, useBuild, usePurchase, useCollectAll, useClaimFrontier, useMintAvatar, useSwitchCommander, useSpecialAttack, useDeployDrone, useDeploySatellite } from "@/hooks/useGameState";
 import { useToast } from "@/hooks/use-toast";
+import { queryClient } from "@/lib/queryClient";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Button } from "@/components/ui/button";
 import { Coins, Shield, Globe } from "lucide-react";
@@ -46,8 +47,13 @@ export function GameLayout() {
     treasuryAddress,
   } = useBlockchainActions();
   const { data: gameState, isLoading, error } = useGameState();
-  const player = useCurrentPlayer();
+  // Find the player that belongs to the currently connected wallet address.
+  // useCurrentPlayer now accepts an address so each wallet sees its own data.
+  const player = useCurrentPlayer(wallet.address);
   const { toast } = useToast();
+
+  // Track which address we have already initialised so we don't fire twice.
+  const initializedAddressRef = useRef<string | null>(null);
 
   const [selectedParcelId, setSelectedParcelId] = useState<string | null>(null);
   const [attackModalOpen, setAttackModalOpen] = useState(false);
@@ -79,27 +85,28 @@ export function GameLayout() {
     if (!seen) setShowOnboarding(true);
   }, []);
 
+  // When a wallet connects (or changes), look up / create the player for that
+  // specific address so each wallet always starts with isolated, fresh data.
   useEffect(() => {
-    if (player && wallet.address && wallet.isConnected) {
-      if (player.address !== wallet.address) {
-        fetch("/api/actions/connect-wallet", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ playerId: player.id, address: wallet.address }),
-        })
-          .then(r => r.json())
-          .then(data => {
-            if (data.welcomeBonus) {
-              toast({
-                title: "Welcome Commander!",
-                description: "You've received 500 FRONTIER tokens as a welcome bonus. Use them to build facilities and grow your empire!",
-              });
-            }
-          })
-          .catch((err) => console.error("Failed to sync wallet address:", err));
-      }
-    }
-  }, [player?.id, wallet.address, wallet.isConnected]);
+    if (!wallet.address || !wallet.isConnected) return;
+    if (initializedAddressRef.current === wallet.address) return;
+
+    initializedAddressRef.current = wallet.address;
+
+    fetch(`/api/game/player-by-address/${encodeURIComponent(wallet.address)}`)
+      .then((r) => r.json())
+      .then((data) => {
+        if (data.welcomeBonus) {
+          toast({
+            title: "Welcome Commander!",
+            description: "You've received 500 FRONTIER tokens as a welcome bonus. Use them to build facilities and grow your empire!",
+          });
+        }
+        // Refresh game state so this player's row is visible immediately.
+        queryClient.invalidateQueries({ queryKey: ["/api/game/state"] });
+      })
+      .catch((err) => console.error("Failed to initialise player for address:", err));
+  }, [wallet.address, wallet.isConnected]);
 
   const handleOnboardingComplete = () => {
     localStorage.setItem("frontier_onboarding_done", "true");

--- a/client/src/hooks/useGameState.ts
+++ b/client/src/hooks/useGameState.ts
@@ -21,10 +21,14 @@ export function usePlayer(playerId: string | null) {
   return gameState.players.find((p) => p.id === playerId) || null;
 }
 
-export function useCurrentPlayer() {
+export function useCurrentPlayer(walletAddress?: string | null) {
   const { data: gameState } = useGameState();
   if (!gameState) return null;
-  return gameState.players.find((p) => !p.isAI) || null;
+  if (walletAddress) {
+    const lower = walletAddress.toLowerCase();
+    return gameState.players.find((p) => p.address.toLowerCase() === lower) ?? null;
+  }
+  return gameState.players.find((p) => !p.isAI) ?? null;
 }
 
 export function useMine() {

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -177,6 +177,54 @@ export async function registerRoutes(
     }
   });
 
+  /**
+   * Wallet-based player lookup / auto-creation.
+   * Called by the client immediately after a wallet connects.
+   * Returns the existing player for that address, or creates a fresh one.
+   * Also grants the 500 FRONTIER welcome bonus on first login.
+   */
+  app.get("/api/game/player-by-address/:address", async (req, res) => {
+    try {
+      const { address } = req.params;
+      if (!address || typeof address !== "string") {
+        return res.status(400).json({ error: "Address is required" });
+      }
+
+      const player = await storage.getOrCreatePlayerByAddress(address);
+
+      let welcomeBonus = false;
+      if (!player.welcomeBonusReceived) {
+        await storage.grantWelcomeBonus(player.id);
+        welcomeBonus = true;
+
+        // Fire-and-forget ASA transfer
+        const asaId = getFrontierAsaId();
+        if (asaId && !address.startsWith("AI_")) {
+          isAddressOptedInToFrontier(address)
+            .then((optedIn) => {
+              if (optedIn) {
+                batchedTransferFrontierASA(address, 500)
+                  .then((txId) =>
+                    console.log(`Welcome bonus: 500 FRONTIER → ${address}, TX: ${txId}`)
+                  )
+                  .catch((err) =>
+                    console.error("Welcome bonus ASA transfer failed:", err)
+                  );
+              }
+            })
+            .catch((err) => console.error("Opt-in check failed:", err));
+        }
+      }
+
+      // Return fresh player data (welcomeBonusReceived is now true)
+      const fresh = await storage.getPlayer(player.id);
+      res.json({ ...fresh, welcomeBonus });
+    } catch (error) {
+      console.error("player-by-address error:", error);
+      res.status(500).json({ error: "Failed to get or create player" });
+    }
+  });
+
   app.get("/api/game/leaderboard", async (req, res) => {
     try {
       const leaderboard = await storage.getLeaderboard();

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -96,6 +96,8 @@ export interface IStorage {
   getPlayer(id: string): Promise<Player | undefined>;
   getBattle(id: string): Promise<Battle | undefined>;
   getLeaderboard(): Promise<LeaderboardEntry[]>;
+  /** Find an existing player by wallet address (case-insensitive), or create a fresh one. */
+  getOrCreatePlayerByAddress(address: string): Promise<Player>;
 
   mineResources(action: MineAction): Promise<{ iron: number; fuel: number; crystal: number }>;
   upgradeBase(action: UpgradeAction): Promise<LandParcel>;
@@ -449,6 +451,45 @@ export class MemStorage implements IStorage {
     if (!player) throw new Error("Player not found");
     if (player.isAI) throw new Error("Cannot update AI player address");
     player.address = address;
+  }
+
+  async getOrCreatePlayerByAddress(address: string): Promise<Player> {
+    await this.initialize();
+    const trimmed = address.trim();
+    const lower = trimmed.toLowerCase();
+    for (const player of this.players.values()) {
+      if (player.address.toLowerCase() === lower) return player;
+    }
+    const id = randomUUID();
+    const displayName = `${trimmed.slice(0, 6)}...${trimmed.slice(-4)}`;
+    const newPlayer: Player = {
+      id,
+      address: trimmed,
+      name: displayName,
+      iron: 200,
+      fuel: 150,
+      crystal: 50,
+      frontier: 0,
+      ownedParcels: [],
+      isAI: false,
+      totalIronMined: 0,
+      totalFuelMined: 0,
+      totalCrystalMined: 0,
+      totalFrontierEarned: 0,
+      totalFrontierBurned: 0,
+      attacksWon: 0,
+      attacksLost: 0,
+      territoriesCaptured: 0,
+      commander: null,
+      commanders: [],
+      activeCommanderIndex: 0,
+      specialAttacks: [],
+      drones: [],
+      satellites: [],
+      welcomeBonusReceived: false,
+    };
+    this.players.set(id, newPlayer);
+    return newPlayer;
   }
 
   async grantWelcomeBonus(playerId: string): Promise<void> {
@@ -1542,44 +1583,48 @@ export class DbStorage implements IStorage {
   }
   /* ✅ INSERT NEW METHOD HERE */
 
-async getOrCreatePlayerByAddress(address: string): Promise<Player> {
-  await this.initialize();
+  async getOrCreatePlayerByAddress(address: string): Promise<Player> {
+    await this.initialize();
 
-  const normalized = address.trim().toLowerCase();
+    const trimmed = address.trim();
+    const normalized = trimmed.toLowerCase();
 
-  const [existing] = await this.db
-    .select()
-    .from(playersTable)
-    .where(eq(playersTable.address, normalized));
+    // Case-insensitive lookup so uppercase Algorand addresses match existing rows.
+    const [existing] = await this.db
+      .select()
+      .from(playersTable)
+      .where(sql`lower(${playersTable.address}) = ${normalized}`);
 
-  if (existing) {
-    const ownedRows = await this.db
-      .select({ id: parcelsTable.id })
-      .from(parcelsTable)
-      .where(eq(parcelsTable.ownerId, existing.id));
+    if (existing) {
+      const ownedRows = await this.db
+        .select({ id: parcelsTable.id })
+        .from(parcelsTable)
+        .where(eq(parcelsTable.ownerId, existing.id));
 
-    return rowToPlayer(existing, ownedRows.map(r => r.id));
+      return rowToPlayer(existing, ownedRows.map(r => r.id));
+    }
+
+    const id = randomUUID();
+    // Preserve original address case (Algorand addresses are uppercase base32).
+    const displayName = `${trimmed.slice(0, 6)}...${trimmed.slice(-4)}`;
+
+    await this.db.insert(playersTable).values({
+      id,
+      address: trimmed,
+      name: displayName,
+      iron: 200,
+      fuel: 150,
+      crystal: 50,
+      frontier: 0,
+    });
+
+    const [created] = await this.db
+      .select()
+      .from(playersTable)
+      .where(eq(playersTable.id, id));
+
+    return rowToPlayer(created, []);
   }
-
-  const id = randomUUID();
-
-  await this.db.insert(playersTable).values({
-    id,
-    address: normalized,
-    name: `${normalized.slice(0, 6)}...${normalized.slice(-4)}`,
-    iron: 200,
-    fuel: 150,
-    crystal: 50,
-    frontier: 0,
-  });
-
-  const [created] = await this.db
-    .select()
-    .from(playersTable)
-    .where(eq(playersTable.id, id));
-
-  return rowToPlayer(created, []);
-}
 
   // ── IStorage – read ────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Root causes fixed:
1. useCurrentPlayer() was returning the first non-AI player regardless of
   which wallet was connected, so all users shared one player record.
2. No server route existed to look up / create a player by wallet address,
   so the client had no way to identify "me" from a fresh session.
3. DbStorage.getOrCreatePlayerByAddress used a case-sensitive WHERE clause
   (eq on a lowercase-normalised value) that failed to match Algorand's
   uppercase base32 addresses stored via updatePlayerAddress, causing
   duplicate player rows and cross-wallet data leakage.
4. The old connect-wallet flow took a playerId derived from the broken
   useCurrentPlayer(), then overwrote that player's address — so the second
   wallet to connect would hijack the first wallet's player record.

Changes:
- IStorage: add getOrCreatePlayerByAddress to the interface
- MemStorage: implement getOrCreatePlayerByAddress with case-insensitive lookup
- DbStorage.getOrCreatePlayerByAddress: use sql`lower(address) = ?` for
  case-insensitive lookup; preserve original address case when inserting
- routes.ts: add GET /api/game/player-by-address/:address that calls
  getOrCreatePlayerByAddress and grants the welcome bonus on first login
- useGameState.ts: useCurrentPlayer now accepts walletAddress param and
  finds the player whose address matches (case-insensitive)
- GameLayout.tsx: on wallet connect, call player-by-address to ensure the
  player exists then invalidate the game-state cache; pass wallet.address to
  useCurrentPlayer so every user controls only their own player

https://claude.ai/code/session_014XyzqqTTBceU4RGnDr98LC