### PR TITLE
feat: Algorand NFT system step 1 — metadata endpoint + plot_nfts table

### DIFF
--- a/client/public/nft/biomes/.gitkeep
+++ b/client/public/nft/biomes/.gitkeep
@@ -1,0 +1,6 @@
+# Place one PNG per biome here (8 files):
+# forest.png  desert.png  mountain.png  plains.png
+# water.png   tundra.png  volcanic.png  swamp.png
+#
+# These are served at /nft/biomes/<biome>.png and referenced by
+# the ARC-3 metadata endpoint GET /nft/metadata/:plotId

--- a/client/public/nft/metadata/.gitkeep
+++ b/client/public/nft/metadata/.gitkeep
@@ -1,0 +1,2 @@
+# Reserved for static/cached metadata JSON files (optional).
+# The canonical metadata endpoint is GET /nft/metadata/:plotId (server-side).

--- a/server/db-schema.ts
+++ b/server/db-schema.ts
@@ -18,6 +18,18 @@ import {
   index,
 } from "drizzle-orm/pg-core";
 
+// ─── plot_nfts ─────────────────────────────────────────────────────────────
+// Tracks on-chain Algorand ASA (NFT) minting state per plot.
+// asset_id is NULL until the plot NFT is minted; minted_to_address is the
+// Algorand wallet that holds the NFT.  This table is append-light: one row
+// per plot, upserted at purchase time and updated when minting succeeds.
+export const plotNfts = pgTable("plot_nfts", {
+  plotId:          integer("plot_id").primaryKey(),
+  assetId:         bigint("asset_id", { mode: "number" }),          // NULL until minted on-chain
+  mintedToAddress: text("minted_to_address"),                        // Algorand wallet address
+  mintedAt:        bigint("minted_at", { mode: "number" }),          // Unix ms timestamp of mint
+});
+
 // ─── game_meta ────────────────────────────────────────────────────────────────
 // Singleton row (id=1) that records whether the world has been seeded and
 // stores the current turn counter / last-update timestamp.

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -4,6 +4,9 @@ import { storage } from "./storage";
 import { mineActionSchema, upgradeActionSchema, attackActionSchema, buildActionSchema, purchaseActionSchema, collectActionSchema, claimFrontierActionSchema, mintAvatarActionSchema, specialAttackActionSchema, deployDroneActionSchema, deploySatelliteActionSchema } from "@shared/schema";
 import { z } from "zod";
 import { initializeBlockchain, getFrontierAsaId, getAdminAddress, getAdminBalance, transferFrontierASA, isAddressOptedInToFrontier, batchedTransferFrontierASA } from "./algorand";
+import { db } from "./db";
+import { parcels as parcelsTable } from "./db-schema";
+import { eq } from "drizzle-orm";
 
 export async function registerRoutes(
   httpServer: Server,
@@ -105,6 +108,67 @@ export async function registerRoutes(
       res.json({ optedIn, asaId: getFrontierAsaId() });
     } catch (error) {
       res.json({ optedIn: false, asaId: getFrontierAsaId() });
+    }
+  });
+
+  // ── NFT Metadata (ARC-3) ────────────────────────────────────────────────────
+  // Public endpoint used by Algorand NFT marketplaces and wallets.
+  // Returns immutable plot attributes only — no mutable game state.
+  // BASE_URL: set PUBLIC_BASE_URL env var in production, or it falls back
+  // to the request's own origin (works in dev and on Replit).
+  app.get("/nft/metadata/:plotId", async (req, res) => {
+    // Reject non-integer plotId values early.
+    const plotId = parseInt(req.params.plotId, 10);
+    if (isNaN(plotId) || plotId < 1) {
+      return res.status(400).json({ error: "plotId must be a positive integer" });
+    }
+
+    // This endpoint requires a real DB (not MemStorage).
+    if (!db) {
+      return res.status(503).json({ error: "Database not available" });
+    }
+
+    try {
+      // Derive base URL from env var first, then fall back to the request origin.
+      const baseUrl =
+        process.env.PUBLIC_BASE_URL ||
+        `${req.protocol}://${req.get("host")}`;
+
+      // Select only the columns needed for immutable ARC-3 metadata.
+      const [parcel] = await db
+        .select({
+          plotId:           parcelsTable.plotId,
+          biome:            parcelsTable.biome,
+          lat:              parcelsTable.lat,
+          lng:              parcelsTable.lng,
+          richness:         parcelsTable.richness,
+          purchasePriceAlgo: parcelsTable.purchasePriceAlgo,
+        })
+        .from(parcelsTable)
+        .where(eq(parcelsTable.plotId, plotId));
+
+      if (!parcel) {
+        return res.status(404).json({ error: "Plot not found" });
+      }
+
+      // ARC-3 style metadata — keep lean; mutable game state is excluded.
+      res.json({
+        name:         `Frontier Plot #${parcel.plotId}`,
+        description:  "A land parcel on the Frontier globe. Own, upgrade, and battle for territory.",
+        image:        `${baseUrl}/nft/biomes/${parcel.biome}.png`,
+        external_url: `${baseUrl}/plot/${parcel.plotId}`,
+        properties: {
+          plotId:            parcel.plotId,
+          biome:             parcel.biome,
+          coordinates:       { lat: parcel.lat, lng: parcel.lng },
+          richness:          parcel.richness,
+          purchasePriceAlgo: parcel.purchasePriceAlgo,
+          version:           1,
+        },
+      });
+    } catch (error) {
+      console.error("NFT metadata error:", error);
+      res.status(500).json({ error: "Failed to fetch NFT metadata" });
     }
   });
 

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -60,7 +60,7 @@ import type { FacilityType, DefenseImprovementType } from "@shared/schema";
 import { generateFibonacciSphere, sphereDistance, type PlotCoord } from "./sphereUtils";
 import { eq, and, desc, lt, sql } from "drizzle-orm";
 import { db } from "./db";
-import { gameMeta, players as playersTable, parcels as parcelsTable, battles as battlesTable, gameEvents as gameEventsTable } from "./db-schema";
+import { gameMeta, players as playersTable, parcels as parcelsTable, battles as battlesTable, gameEvents as gameEventsTable, plotNfts as plotNftsTable } from "./db-schema";
 import type { DB } from "./db";
 
 const MICRO = 1_000_000;
@@ -1441,6 +1441,17 @@ export class DbStorage implements IStorage {
     // ── Schema migrations (safe to run on every startup) ─────────────────────
     // Add columns introduced after the initial DB release so that existing
     // deployments self-heal without requiring a manual `drizzle-kit push`.
+
+    // NFT tracking table — created here so no separate migration step is needed.
+    await this.db.execute(sql`
+      CREATE TABLE IF NOT EXISTS plot_nfts (
+        plot_id           INT PRIMARY KEY,
+        asset_id          BIGINT,
+        minted_to_address TEXT,
+        minted_at         BIGINT
+      )
+    `);
+
     await this.db.execute(
       sql`ALTER TABLE players ADD COLUMN IF NOT EXISTS total_crystal_mined REAL NOT NULL DEFAULT 0`
     );


### PR DESCRIPTION
- Confirm BIOMES list matches shared/schema.ts (forest/desert/mountain/
  plains/water/tundra/volcanic/swamp)
- Add client/public/nft/biomes/ and client/public/nft/metadata/ asset
  folders with .gitkeep placeholders (drop one PNG per biome to activate)
- Add GET /nft/metadata/:plotId ARC-3 metadata endpoint (server/routes.ts):
  · Queries parcels by integer plotId
  · Returns name/description/image/external_url/properties JSON
  · BASE_URL = PUBLIC_BASE_URL env var or request origin
  · 400 on bad input, 503 if DB unavailable, 404 if plot missing
  · Excludes mutable game state (improvements/resources/battles)
- Add plot_nfts Drizzle schema (server/db-schema.ts):
  · plot_id INT PK, asset_id BIGINT, minted_to_address TEXT, minted_at BIGINT
- Add CREATE TABLE IF NOT EXISTS plot_nfts migration in _doInitialize()
  (server/storage.ts) — self-heals existing deployments on startup

https://claude.ai/code/session_01KAUFRz1qQSKAgNfsUQAKvp