### PR TITLE
feat: implement real on-chain Plot NFTs (Algorand ASA) on TestNet

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,51 @@ Server binds to port 5000. The frontend and backend are served from the same por
 
 ---
 
+---
+
+## Plot NFTs — Verification Commands
+
+Each purchased plot is minted as an Algorand ASA (total=1, decimals=0) on TestNet.
+
+### Check NFT metadata (ARC-3 JSON)
+```bash
+curl https://frontier-al--kudbeex.replit.app/nft/metadata/1
+```
+Returns JSON with `name`, `description`, `image` (biome SVG), `external_url`, and `properties`.
+
+### Query the on-chain NFT record for a plot
+```bash
+curl https://frontier-al--kudbeex.replit.app/api/nft/plot/1
+```
+Returns `{ plotId, assetId, mintedToAddress, mintedAt, explorerUrl }`.
+
+### Query plot_nfts table directly (requires DB access)
+```sql
+SELECT plot_id, asset_id, minted_to_address, minted_at
+FROM plot_nfts
+WHERE plot_id = 1;
+```
+
+### View the asset in Algorand TestNet explorer
+Once you have the `assetId` from the API:
+```
+https://testnet.algoexplorer.io/asset/<assetId>
+```
+
+### Check the asset in a wallet
+1. Open Pera Wallet or LUTE Wallet connected to **Algorand TestNet**
+2. Opt in to the asset using the `assetId` returned by `/api/nft/plot/:plotId`
+3. The Plot NFT will appear in your wallet assets list
+
+### Note on opt-in
+Algorand requires receivers to opt in to any ASA before they can hold it.
+Since the Plot NFT ASA is created at purchase time, the buyer must opt in
+after learning the `assetId`. The admin wallet holds the NFT until the buyer
+opts in. A future `/api/actions/claim-plot-nft` endpoint can automate the
+transfer once the buyer has opted in.
+
+---
+
 ## License
 
 This is proprietary software. All rights reserved. See [LICENSE](LICENSE) for details.

--- a/client/public/nft/biomes/desert.svg
+++ b/client/public/nft/biomes/desert.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400" width="400" height="400">
+  <defs>
+    <radialGradient id="sky" cx="50%" cy="30%" r="60%">
+      <stop offset="0%" stop-color="#f5c842"/>
+      <stop offset="100%" stop-color="#c87820"/>
+    </radialGradient>
+    <radialGradient id="sun" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#fff8a0"/>
+      <stop offset="100%" stop-color="#f5c842"/>
+    </radialGradient>
+  </defs>
+  <rect width="400" height="400" fill="url(#sky)"/>
+  <!-- Sand dunes -->
+  <ellipse cx="100" cy="340" rx="160" ry="60" fill="#d4a030"/>
+  <ellipse cx="320" cy="330" rx="140" ry="50" fill="#c88820"/>
+  <ellipse cx="200" cy="310" rx="220" ry="70" fill="#e8b840"/>
+  <!-- Sun -->
+  <circle cx="320" cy="80" r="40" fill="url(#sun)"/>
+  <!-- Cactus -->
+  <rect x="155" y="200" width="18" height="100" fill="#5a8a30"/>
+  <rect x="125" y="230" width="30" height="14" fill="#5a8a30"/>
+  <rect x="173" y="220" width="30" height="14" fill="#5a8a30"/>
+  <!-- Label -->
+  <text x="200" y="385" font-family="Arial,sans-serif" font-size="28" font-weight="bold" fill="#7a3000" text-anchor="middle">DESERT</text>
+  <!-- Border -->
+  <rect x="2" y="2" width="396" height="396" fill="none" stroke="#c87820" stroke-width="4"/>
+</svg>

--- a/client/public/nft/biomes/forest.svg
+++ b/client/public/nft/biomes/forest.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400" width="400" height="400">
+  <defs>
+    <radialGradient id="bg" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#2d5a27"/>
+      <stop offset="100%" stop-color="#1a3a14"/>
+    </radialGradient>
+  </defs>
+  <rect width="400" height="400" fill="url(#bg)"/>
+  <!-- Ground -->
+  <rect x="0" y="300" width="400" height="100" fill="#1a3a14"/>
+  <!-- Trees -->
+  <polygon points="200,80 160,200 240,200" fill="#3d7a35"/>
+  <polygon points="200,120 150,240 250,240" fill="#4a9040"/>
+  <rect x="190" y="240" width="20" height="60" fill="#6b4423"/>
+  <polygon points="120,120 85,220 155,220" fill="#3d7a35"/>
+  <polygon points="120,155 80,255 160,255" fill="#4a9040"/>
+  <rect x="112" y="255" width="16" height="45" fill="#6b4423"/>
+  <polygon points="280,130 245,230 315,230" fill="#3d7a35"/>
+  <polygon points="280,165 240,265 320,265" fill="#4a9040"/>
+  <rect x="272" y="265" width="16" height="35" fill="#6b4423"/>
+  <!-- Label -->
+  <text x="200" y="370" font-family="Arial,sans-serif" font-size="28" font-weight="bold" fill="#a0f080" text-anchor="middle">FOREST</text>
+  <!-- Border -->
+  <rect x="2" y="2" width="396" height="396" fill="none" stroke="#4a9040" stroke-width="4"/>
+</svg>

--- a/client/public/nft/biomes/mountain.svg
+++ b/client/public/nft/biomes/mountain.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400" width="400" height="400">
+  <defs>
+    <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#5080c0"/>
+      <stop offset="100%" stop-color="#8ab0e0"/>
+    </linearGradient>
+  </defs>
+  <rect width="400" height="400" fill="url(#sky)"/>
+  <!-- Far mountains -->
+  <polygon points="0,280 80,140 160,280" fill="#607090"/>
+  <polygon points="240,280 340,100 400,280" fill="#506080"/>
+  <!-- Main mountain -->
+  <polygon points="50,320 200,60 350,320" fill="#708090"/>
+  <!-- Snow cap -->
+  <polygon points="165,120 200,60 235,120 220,130 200,115 180,130" fill="white"/>
+  <!-- Ground -->
+  <rect x="0" y="320" width="400" height="80" fill="#405060"/>
+  <!-- Label -->
+  <text x="200" y="385" font-family="Arial,sans-serif" font-size="24" font-weight="bold" fill="#c0d8f0" text-anchor="middle">MOUNTAIN</text>
+  <!-- Border -->
+  <rect x="2" y="2" width="396" height="396" fill="none" stroke="#708090" stroke-width="4"/>
+</svg>

--- a/client/public/nft/biomes/plains.svg
+++ b/client/public/nft/biomes/plains.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400" width="400" height="400">
+  <defs>
+    <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#70b0f0"/>
+      <stop offset="100%" stop-color="#a8d0f8"/>
+    </linearGradient>
+    <linearGradient id="grass" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#80c040"/>
+      <stop offset="100%" stop-color="#508020"/>
+    </linearGradient>
+  </defs>
+  <rect width="400" height="400" fill="url(#sky)"/>
+  <!-- Rolling hills -->
+  <ellipse cx="0" cy="280" rx="200" ry="60" fill="#90cc50"/>
+  <ellipse cx="400" cy="290" rx="200" ry="55" fill="#85c048"/>
+  <!-- Main ground -->
+  <rect x="0" y="260" width="400" height="140" fill="url(#grass)"/>
+  <!-- Grass blades -->
+  <line x1="60" y1="260" x2="55" y2="230" stroke="#60a030" stroke-width="3"/>
+  <line x1="90" y1="255" x2="95" y2="225" stroke="#60a030" stroke-width="3"/>
+  <line x1="150" y1="260" x2="145" y2="228" stroke="#60a030" stroke-width="3"/>
+  <line x1="250" y1="258" x2="255" y2="226" stroke="#60a030" stroke-width="3"/>
+  <line x1="310" y1="262" x2="305" y2="230" stroke="#60a030" stroke-width="3"/>
+  <line x1="360" y1="255" x2="365" y2="223" stroke="#60a030" stroke-width="3"/>
+  <!-- Clouds -->
+  <ellipse cx="100" cy="100" rx="55" ry="25" fill="white" opacity="0.85"/>
+  <ellipse cx="130" cy="92" rx="40" ry="22" fill="white" opacity="0.85"/>
+  <ellipse cx="290" cy="120" rx="50" ry="22" fill="white" opacity="0.85"/>
+  <ellipse cx="315" cy="112" rx="35" ry="20" fill="white" opacity="0.85"/>
+  <!-- Label -->
+  <text x="200" y="385" font-family="Arial,sans-serif" font-size="28" font-weight="bold" fill="#204010" text-anchor="middle">PLAINS</text>
+  <!-- Border -->
+  <rect x="2" y="2" width="396" height="396" fill="none" stroke="#80c040" stroke-width="4"/>
+</svg>

--- a/client/public/nft/biomes/swamp.svg
+++ b/client/public/nft/biomes/swamp.svg
@@ -1,0 +1,39 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400" width="400" height="400">
+  <defs>
+    <radialGradient id="bg" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#2a3a18"/>
+      <stop offset="100%" stop-color="#151e0a"/>
+    </radialGradient>
+    <radialGradient id="water" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#2a4028"/>
+      <stop offset="100%" stop-color="#182818"/>
+    </radialGradient>
+  </defs>
+  <rect width="400" height="400" fill="url(#bg)"/>
+  <!-- Murky water -->
+  <ellipse cx="200" cy="310" rx="200" ry="60" fill="url(#water)"/>
+  <!-- Water ripples -->
+  <ellipse cx="140" cy="305" rx="50" ry="10" fill="none" stroke="#3a5530" stroke-width="2" opacity="0.6"/>
+  <ellipse cx="280" cy="320" rx="45" ry="8" fill="none" stroke="#3a5530" stroke-width="2" opacity="0.5"/>
+  <!-- Mangrove/dead trees -->
+  <rect x="90" y="160" width="12" height="140" fill="#3a2810"/>
+  <rect x="75" y="200" width="45" height="8" fill="#3a2810"/>
+  <rect x="70" y="190" width="12" height="60" fill="#3a2810"/>
+  <rect x="100" y="175" width="35" height="8" fill="#3a2810"/>
+  <rect x="295" y="170" width="12" height="130" fill="#3a2810"/>
+  <rect x="280" y="210" width="40" height="8" fill="#3a2810"/>
+  <rect x="320" y="195" width="12" height="55" fill="#3a2810"/>
+  <!-- Moss/vegetation -->
+  <ellipse cx="102" cy="162" rx="22" ry="12" fill="#3a5520" opacity="0.9"/>
+  <ellipse cx="302" cy="172" rx="20" ry="11" fill="#3a5520" opacity="0.9"/>
+  <!-- Fog wisps -->
+  <ellipse cx="200" cy="280" rx="80" ry="15" fill="#a0c080" opacity="0.12"/>
+  <ellipse cx="120" cy="270" rx="55" ry="12" fill="#90b070" opacity="0.10"/>
+  <!-- Lily pads -->
+  <ellipse cx="160" cy="320" rx="20" ry="8" fill="#3a6025" opacity="0.8"/>
+  <ellipse cx="250" cy="330" rx="18" ry="7" fill="#3a6025" opacity="0.8"/>
+  <!-- Label -->
+  <text x="200" y="385" font-family="Arial,sans-serif" font-size="28" font-weight="bold" fill="#80c060" text-anchor="middle">SWAMP</text>
+  <!-- Border -->
+  <rect x="2" y="2" width="396" height="396" fill="none" stroke="#3a5520" stroke-width="4"/>
+</svg>

--- a/client/public/nft/biomes/tundra.svg
+++ b/client/public/nft/biomes/tundra.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400" width="400" height="400">
+  <defs>
+    <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#90b8d8"/>
+      <stop offset="100%" stop-color="#c8dff0"/>
+    </linearGradient>
+    <linearGradient id="snow" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#f0f8ff"/>
+      <stop offset="100%" stop-color="#c8dff0"/>
+    </linearGradient>
+  </defs>
+  <rect width="400" height="400" fill="url(#sky)"/>
+  <!-- Frozen ground -->
+  <rect x="0" y="260" width="400" height="140" fill="url(#snow)"/>
+  <!-- Snow mounds -->
+  <ellipse cx="80" cy="265" rx="100" ry="30" fill="#e8f4ff"/>
+  <ellipse cx="300" cy="270" rx="120" ry="28" fill="#ddeeff"/>
+  <!-- Ice cracks -->
+  <path d="M100,300 L140,320 L120,340" fill="none" stroke="#a0c8e0" stroke-width="2"/>
+  <path d="M260,310 L240,330 L270,345" fill="none" stroke="#a0c8e0" stroke-width="2"/>
+  <!-- Aurora borealis -->
+  <path d="M0,60 Q100,30 200,60 Q300,90 400,60" fill="none" stroke="#40e080" stroke-width="6" opacity="0.6"/>
+  <path d="M0,80 Q100,50 200,80 Q300,110 400,80" fill="none" stroke="#80e0c0" stroke-width="4" opacity="0.5"/>
+  <path d="M0,100 Q100,70 200,100 Q300,130 400,100" fill="none" stroke="#40c0e0" stroke-width="3" opacity="0.4"/>
+  <!-- Stars -->
+  <circle cx="50" cy="30" r="2" fill="white"/>
+  <circle cx="150" cy="20" r="2" fill="white"/>
+  <circle cx="250" cy="35" r="2" fill="white"/>
+  <circle cx="350" cy="15" r="2" fill="white"/>
+  <circle cx="320" cy="45" r="1.5" fill="white"/>
+  <!-- Label -->
+  <text x="200" y="385" font-family="Arial,sans-serif" font-size="28" font-weight="bold" fill="#204060" text-anchor="middle">TUNDRA</text>
+  <!-- Border -->
+  <rect x="2" y="2" width="396" height="396" fill="none" stroke="#90b8d8" stroke-width="4"/>
+</svg>

--- a/client/public/nft/biomes/volcanic.svg
+++ b/client/public/nft/biomes/volcanic.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400" width="400" height="400">
+  <defs>
+    <radialGradient id="sky" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#4a1010"/>
+      <stop offset="100%" stop-color="#1a0808"/>
+    </radialGradient>
+    <radialGradient id="lava" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#ff8020"/>
+      <stop offset="100%" stop-color="#c03000"/>
+    </radialGradient>
+  </defs>
+  <rect width="400" height="400" fill="url(#sky)"/>
+  <!-- Volcano body -->
+  <polygon points="30,380 200,80 370,380" fill="#2a1010"/>
+  <!-- Lava glow at crater -->
+  <ellipse cx="200" cy="100" rx="35" ry="15" fill="#ff4000" opacity="0.9"/>
+  <!-- Lava flows -->
+  <path d="M185,120 Q175,180 165,240 Q155,280 170,320" fill="none" stroke="#ff6020" stroke-width="8" opacity="0.8"/>
+  <path d="M215,120 Q228,185 235,250 Q242,285 230,330" fill="none" stroke="#ff4010" stroke-width="7" opacity="0.7"/>
+  <!-- Lava pool at base -->
+  <ellipse cx="200" cy="370" rx="100" ry="20" fill="url(#lava)" opacity="0.9"/>
+  <!-- Smoke/ash -->
+  <ellipse cx="190" cy="65" rx="25" ry="15" fill="#504040" opacity="0.7"/>
+  <ellipse cx="210" cy="50" rx="20" ry="12" fill="#604040" opacity="0.6"/>
+  <ellipse cx="180" cy="40" rx="18" ry="10" fill="#504040" opacity="0.5"/>
+  <!-- Embers -->
+  <circle cx="160" cy="90" r="4" fill="#ff8020" opacity="0.9"/>
+  <circle cx="240" cy="70" r="3" fill="#ff6010" opacity="0.8"/>
+  <circle cx="220" cy="50" r="3" fill="#ffaa30" opacity="0.7"/>
+  <!-- Label -->
+  <text x="200" y="395" font-family="Arial,sans-serif" font-size="24" font-weight="bold" fill="#ff8040" text-anchor="middle">VOLCANIC</text>
+  <!-- Border -->
+  <rect x="2" y="2" width="396" height="396" fill="none" stroke="#c03000" stroke-width="4"/>
+</svg>

--- a/client/public/nft/biomes/water.svg
+++ b/client/public/nft/biomes/water.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400" width="400" height="400">
+  <defs>
+    <linearGradient id="ocean" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#1060c0"/>
+      <stop offset="100%" stop-color="#003080"/>
+    </linearGradient>
+    <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#2070e0"/>
+      <stop offset="100%" stop-color="#60a0f0"/>
+    </linearGradient>
+  </defs>
+  <rect width="400" height="400" fill="url(#sky)"/>
+  <!-- Ocean -->
+  <rect x="0" y="200" width="400" height="200" fill="url(#ocean)"/>
+  <!-- Waves -->
+  <path d="M0,210 Q50,195 100,210 Q150,225 200,210 Q250,195 300,210 Q350,225 400,210" fill="none" stroke="#4090e0" stroke-width="3"/>
+  <path d="M0,235 Q50,220 100,235 Q150,250 200,235 Q250,220 300,235 Q350,250 400,235" fill="none" stroke="#4090e0" stroke-width="3"/>
+  <path d="M0,260 Q50,245 100,260 Q150,275 200,260 Q250,245 300,260 Q350,275 400,260" fill="none" stroke="#3080d0" stroke-width="2"/>
+  <!-- Sunlight reflection -->
+  <ellipse cx="200" cy="300" rx="30" ry="8" fill="#80c0ff" opacity="0.4"/>
+  <!-- Clouds -->
+  <ellipse cx="120" cy="90" rx="60" ry="28" fill="white" opacity="0.90"/>
+  <ellipse cx="155" cy="80" rx="45" ry="25" fill="white" opacity="0.90"/>
+  <ellipse cx="300" cy="110" rx="55" ry="25" fill="white" opacity="0.90"/>
+  <!-- Label -->
+  <text x="200" y="385" font-family="Arial,sans-serif" font-size="28" font-weight="bold" fill="#a0d0ff" text-anchor="middle">WATER</text>
+  <!-- Border -->
+  <rect x="2" y="2" width="396" height="396" fill="none" stroke="#1060c0" stroke-width="4"/>
+</svg>

--- a/server/algorand.ts
+++ b/server/algorand.ts
@@ -1,4 +1,5 @@
 import algosdk from "algosdk";
+import { eq } from "drizzle-orm";
 import { db } from "./db";
 import { plotNfts } from "./db-schema";
 
@@ -365,49 +366,145 @@ export async function initializeBlockchain(): Promise<{ asaId: number | null; ad
 }
 
 // ---------------------------------------------------------------------------
-// Plot NFT minting (stub — no real Algorand SDK call yet)
+// Plot NFT minting — real Algorand ASA on TestNet
 // ---------------------------------------------------------------------------
 
-let _mintCounter = 0;
-
 /**
- * Mint a plot NFT to the given Algorand address.
+ * Mint a Frontier Plot NFT (Algorand ASA) for the given plot and transfer it
+ * to the buyer's wallet address.
  *
- * This is a stub implementation: it generates a fake asset ID and writes the
- * result to the `plot_nfts` table.  Real on-chain minting via the Algorand SDK
- * will replace the fake-ID generation once the integration is ready.
+ * ASA parameters (TestNet):
+ *   assetName  = `Frontier Plot #<plotId>`
+ *   unitName   = `PLOT`
+ *   total      = 1  (true NFT — indivisible)
+ *   decimals   = 0
+ *   manager    = admin (allows metadata URL updates in future)
+ *   reserve    = admin (displayed as "reserve" in explorers)
+ *   freeze     = admin (allows freeze on TestNet for recovery)
+ *   clawback   = admin (allows clawback on TestNet for recovery)
  *
- * @param plotId  - The integer plot identifier (primary key in `plot_nfts`).
- * @param address - The Algorand wallet address that will own the NFT.
- * @returns       `{ assetId }` — the (fake) Algorand ASA asset ID.
+ * NOTE: On mainnet, freeze and clawback should be set to "" (empty string)
+ * to give true ownership to buyers. Kept as admin on TestNet for safety.
+ *
+ * Transfer step: After creation the 1 unit lives in the admin wallet.
+ * We attempt to send it to `address`. If the buyer has not yet opted in to
+ * this specific ASA (which is always the case for a freshly-minted NFT),
+ * the transfer will fail gracefully — the assetId is still recorded and the
+ * admin holds the NFT until the buyer opts in.
+ *
+ * @param plotId  - Integer plot identifier (primary key in `plot_nfts`).
+ * @param address - Algorand wallet address that should receive the NFT.
+ * @returns       `{ assetId }` — the real on-chain Algorand ASA asset ID.
  */
 export async function mintPlotNftToAddress(
   plotId: number,
   address: string
 ): Promise<{ assetId: number }> {
-  // Generate a unique fake asset ID without calling the Algorand SDK.
-  const assetId = Date.now() + (++_mintCounter);
-  const mintedAt = Date.now();
+  // Safety: if this plot has already been minted, return the existing assetId.
+  const [existing] = await db
+    .select()
+    .from(plotNfts)
+    .where(eq(plotNfts.plotId, plotId));
 
+  if (existing?.assetId) {
+    console.log(
+      `[mintPlotNftToAddress] plotId=${plotId} already minted, assetId=${existing.assetId}`
+    );
+    return { assetId: Number(existing.assetId) };
+  }
+
+  const account = getAdminAccount();
+  const PUBLIC_BASE_URL =
+    process.env.PUBLIC_BASE_URL || "https://frontier-al--kudbeex.replit.app";
+
+  // ── Step 1: Create the NFT ASA ────────────────────────────────────────────
+  const createParams = await algodClient.getTransactionParams().do();
+
+  const createTxn = algosdk.makeAssetCreateTxnWithSuggestedParamsFromObject({
+    sender: account.addr.toString(),
+    total: BigInt(1),
+    decimals: 0,
+    defaultFrozen: false,
+    unitName: "PLOT",
+    assetName: `Frontier Plot #${plotId}`,
+    assetURL: `${PUBLIC_BASE_URL}/nft/metadata/${plotId}`,
+    // All roles set to admin for TestNet recovery purposes.
+    // On mainnet, freeze and clawback should be empty strings.
+    manager: account.addr.toString(),
+    reserve: account.addr.toString(),
+    freeze: account.addr.toString(),
+    clawback: account.addr.toString(),
+    suggestedParams: createParams,
+    note: new TextEncoder().encode(`FRONTIER Plot NFT #${plotId} - TestNet`),
+  });
+
+  const signedCreate = createTxn.signTxn(account.sk);
+  const createResp = await algodClient.sendRawTransaction(signedCreate).do();
+  const createTxId = createResp.txid || createTxn.txID();
+
+  const confirmedCreate = await algosdk.waitForConfirmation(algodClient, createTxId, 4);
+  const assetId = Number(
+    (confirmedCreate as any).assetIndex ?? (confirmedCreate as any)["asset-index"]
+  );
+
+  if (!assetId || assetId === 0) {
+    throw new Error(
+      `Plot NFT ASA creation failed for plotId=${plotId}: no assetIndex in confirmed txn`
+    );
+  }
+
+  console.log(
+    `[mintPlotNftToAddress] plotId=${plotId} ASA created, assetId=${assetId}, TX: ${createTxId}`
+  );
+
+  // ── Step 2: Transfer the 1 unit to the buyer ──────────────────────────────
+  // The buyer must have opted in to this ASA before they can receive it.
+  // For freshly-minted NFTs the buyer cannot have opted in yet, so the
+  // transfer will typically fail on the first attempt. The assetId is still
+  // recorded — the buyer can opt in later and an admin transfer can follow.
+  let mintedToAddress = account.addr.toString(); // admin holds by default
+
+  try {
+    const transferParams = await algodClient.getTransactionParams().do();
+    const transferTxn = algosdk.makeAssetTransferTxnWithSuggestedParamsFromObject({
+      sender: account.addr.toString(),
+      receiver: address,
+      amount: 1,
+      assetIndex: assetId,
+      suggestedParams: transferParams,
+      note: new TextEncoder().encode(`FRONTIER Plot #${plotId} NFT to buyer`),
+    });
+
+    const signedTransfer = transferTxn.signTxn(account.sk);
+    const transferResp = await algodClient.sendRawTransaction(signedTransfer).do();
+    const transferTxId = transferResp.txid || transferTxn.txID();
+    await algosdk.waitForConfirmation(algodClient, transferTxId, 4);
+
+    mintedToAddress = address;
+    console.log(
+      `[mintPlotNftToAddress] plotId=${plotId} NFT transferred to ${address}, TX: ${transferTxId}`
+    );
+  } catch (err) {
+    console.warn(
+      `[mintPlotNftToAddress] Transfer to ${address} failed — buyer likely not opted in to` +
+        ` assetId=${assetId}. NFT held by admin until buyer opts in.`,
+      err instanceof Error ? err.message : err
+    );
+  }
+
+  // ── Step 3: Persist to plot_nfts (upsert on plotId) ──────────────────────
+  const mintedAt = Date.now();
   await db
     .insert(plotNfts)
-    .values({
-      plotId,
-      assetId,
-      mintedToAddress: address,
-      mintedAt,
-    })
+    .values({ plotId, assetId, mintedToAddress, mintedAt })
     .onConflictDoUpdate({
       target: plotNfts.plotId,
-      set: {
-        assetId,
-        mintedToAddress: address,
-        mintedAt,
-      },
+      set: { assetId, mintedToAddress, mintedAt },
     });
 
   console.log(
-    `[mintPlotNftToAddress] plotId=${plotId} address=${address} fakeAssetId=${assetId}`
+    `[mintPlotNftToAddress] plotId=${plotId} recorded in plot_nfts,` +
+      ` assetId=${assetId}, holder=${mintedToAddress}`
   );
 
   return { assetId };

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -3,9 +3,9 @@ import { createServer, type Server } from "http";
 import { storage } from "./storage";
 import { mineActionSchema, upgradeActionSchema, attackActionSchema, buildActionSchema, purchaseActionSchema, collectActionSchema, claimFrontierActionSchema, mintAvatarActionSchema, specialAttackActionSchema, deployDroneActionSchema, deploySatelliteActionSchema } from "@shared/schema";
 import { z } from "zod";
-import { initializeBlockchain, getFrontierAsaId, getAdminAddress, getAdminBalance, transferFrontierASA, isAddressOptedInToFrontier, batchedTransferFrontierASA } from "./algorand";
+import { initializeBlockchain, getFrontierAsaId, getAdminAddress, getAdminBalance, transferFrontierASA, isAddressOptedInToFrontier, batchedTransferFrontierASA, mintPlotNftToAddress } from "./algorand";
 import { db } from "./db";
-import { parcels as parcelsTable } from "./db-schema";
+import { parcels as parcelsTable, plotNfts as plotNftsTable } from "./db-schema";
 import { eq } from "drizzle-orm";
 
 export async function registerRoutes(
@@ -129,10 +129,14 @@ export async function registerRoutes(
     }
 
     try {
-      // Derive base URL from env var first, then fall back to the request origin.
+      // Derive base URL: env var (production) → request origin (dev/fallback).
+      // Never use localhost in production image/external_url fields.
+      const reqHost = req.get("host") || "";
       const baseUrl =
         process.env.PUBLIC_BASE_URL ||
-        `${req.protocol}://${req.get("host")}`;
+        (reqHost.includes("localhost") || reqHost.includes("127.0.0.1")
+          ? "https://frontier-al--kudbeex.replit.app"
+          : `${req.protocol}://${reqHost}`);
 
       // Select only the columns needed for immutable ARC-3 metadata.
       const [parcel] = await db
@@ -155,7 +159,7 @@ export async function registerRoutes(
       res.json({
         name:         `Frontier Plot #${parcel.plotId}`,
         description:  "A land parcel on the Frontier globe. Own, upgrade, and battle for territory.",
-        image:        `${baseUrl}/nft/biomes/${parcel.biome}.png`,
+        image:        `${baseUrl}/nft/biomes/${parcel.biome}.svg`,
         external_url: `${baseUrl}/plot/${parcel.plotId}`,
         properties: {
           plotId:            parcel.plotId,
@@ -169,6 +173,42 @@ export async function registerRoutes(
     } catch (error) {
       console.error("NFT metadata error:", error);
       res.status(500).json({ error: "Failed to fetch NFT metadata" });
+    }
+  });
+
+  // ── Plot NFT on-chain record lookup ────────────────────────────────────────
+  // Returns the plot_nfts row for a given plotId.
+  // Useful for checking if a plot has been minted and retrieving its assetId.
+  app.get("/api/nft/plot/:plotId", async (req, res) => {
+    const plotId = parseInt(req.params.plotId, 10);
+    if (isNaN(plotId) || plotId < 1) {
+      return res.status(400).json({ error: "plotId must be a positive integer" });
+    }
+    if (!db) {
+      return res.status(503).json({ error: "Database not available" });
+    }
+    try {
+      const [row] = await db
+        .select()
+        .from(plotNftsTable)
+        .where(eq(plotNftsTable.plotId, plotId));
+
+      if (!row) {
+        return res.status(404).json({ error: "No NFT record for this plot" });
+      }
+
+      res.json({
+        plotId: row.plotId,
+        assetId: row.assetId ? Number(row.assetId) : null,
+        mintedToAddress: row.mintedToAddress,
+        mintedAt: row.mintedAt ? Number(row.mintedAt) : null,
+        explorerUrl: row.assetId
+          ? `https://testnet.algoexplorer.io/asset/${row.assetId}`
+          : null,
+      });
+    } catch (error) {
+      console.error("NFT plot lookup error:", error);
+      res.status(500).json({ error: "Failed to fetch NFT record" });
     }
   });
 
@@ -418,7 +458,49 @@ export async function registerRoutes(
     try {
       const action = purchaseActionSchema.parse(req.body);
       const parcel = await storage.purchaseLand(action);
-      res.json({ success: true, parcel });
+
+      // Mint a Plot NFT (Algorand ASA) for human players only.
+      // AI purchases do not receive NFTs. Fire-and-forget so the HTTP
+      // response is immediate; minting happens in the background.
+      let nftAssetId: number | null = null;
+      const player = await storage.getPlayer(action.playerId);
+      const buyerAddress = player?.address;
+      const isHumanBuyer =
+        buyerAddress &&
+        !buyerAddress.startsWith("AI_") &&
+        buyerAddress !== "PLAYER_WALLET" &&
+        buyerAddress.length === 58;
+
+      if (isHumanBuyer && db) {
+        // Check if already minted (idempotency guard)
+        const [existingNft] = await db
+          .select()
+          .from(plotNftsTable)
+          .where(eq(plotNftsTable.plotId, parcel.plotId));
+
+        if (existingNft?.assetId) {
+          nftAssetId = Number(existingNft.assetId);
+          console.log(
+            `[purchase] plotId=${parcel.plotId} NFT already exists, assetId=${nftAssetId}`
+          );
+        } else {
+          // Fire-and-forget: mint in background, don't block response
+          mintPlotNftToAddress(parcel.plotId, buyerAddress)
+            .then(({ assetId }) => {
+              console.log(
+                `[purchase] plotId=${parcel.plotId} NFT minted, assetId=${assetId}`
+              );
+            })
+            .catch((err) => {
+              console.error(
+                `[purchase] NFT minting failed for plotId=${parcel.plotId}:`,
+                err instanceof Error ? err.message : err
+              );
+            });
+        }
+      }
+
+      res.json({ success: true, parcel, nftAssetId });
     } catch (error) {
       if (error instanceof z.ZodError) return res.status(400).json({ error: "Invalid request data" });
       res.status(400).json({ error: error instanceof Error ? error.message : "Purchase failed" });


### PR DESCRIPTION
- Replace stub mintPlotNftToAddress with real Algorand SDK minting:
  * Creates ASA: assetName="Frontier Plot #<id>", unitName="PLOT",
    total=1, decimals=0 — true 1-of-1 NFT
  * manager/reserve/freeze/clawback = admin for TestNet recovery
  * assetURL points to /nft/metadata/<plotId> on production base URL
  * Attempts transfer to buyer; gracefully holds in admin wallet if
    buyer hasn't opted in yet (Algorand opt-in requirement)
  * Safety guard: returns existing assetId if plot already minted

- Add /api/nft/plot/:plotId endpoint to query plot_nfts record,
  returning assetId, mintedToAddress, mintedAt and Algoexplorer URL

- Update /api/actions/purchase to fire-and-forget NFT minting for
  human players only (AI buys are skipped); idempotency checked first

- Update /nft/metadata/:plotId image path from .png → .svg; add
  localhost-aware BASE_URL guard to prevent localhost in prod metadata

- Add 8 biome SVG images (forest, desert, mountain, plains, water,
  tundra, volcanic, swamp) to client/public/nft/biomes/

- Add plot_nfts upsert on plotId for all DB writes

- Add README "Plot NFTs — Verification Commands" section with curl
  examples, SQL query, Algoexplorer URL, and opt-in explanation

https://claude.ai/code/session_01SBWzFKo6ftp7cnsrg3DJ8Q