### PR TITLE
feat: interactive attack screen with commander selection and battle watch modal

### DIFF
--- a/client/src/components/game/AttackModal.tsx
+++ b/client/src/components/game/AttackModal.tsx
@@ -1,20 +1,52 @@
 import { useState } from "react";
-import { Swords, Pickaxe, Fuel, AlertTriangle, ChevronUp, ChevronDown } from "lucide-react";
+import { Swords, Pickaxe, Fuel, AlertTriangle, ChevronUp, ChevronDown, Clock, Shield, Zap, Skull, Lock } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from "@/components/ui/dialog";
 import { Slider } from "@/components/ui/slider";
 import { Badge } from "@/components/ui/badge";
+import { ScrollArea } from "@/components/ui/scroll-area";
 import { cn } from "@/lib/utils";
-import type { LandParcel, Player } from "@shared/schema";
-import { ATTACK_BASE_COST, biomeBonuses } from "@shared/schema";
+import type { LandParcel, Player, CommanderAvatar } from "@shared/schema";
+import { ATTACK_BASE_COST, BATTLE_DURATION_MS, biomeBonuses } from "@shared/schema";
 
 interface AttackModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   targetParcel: LandParcel | null;
   attacker: Player | null;
-  onAttack: (troops: number, iron: number, fuel: number) => void;
+  onAttack: (troops: number, iron: number, fuel: number, commanderId?: string) => void;
   isAttacking: boolean;
+}
+
+const TIER_ICON = {
+  sentinel: Shield,
+  phantom: Zap,
+  reaper: Skull,
+};
+
+const TIER_COLOR = {
+  sentinel: "text-blue-400",
+  phantom: "text-purple-400",
+  reaper: "text-red-400",
+};
+
+const TIER_BORDER_SELECTED = {
+  sentinel: "border-blue-400 bg-blue-400/10",
+  phantom: "border-purple-400 bg-purple-400/10",
+  reaper: "border-red-400 bg-red-400/10",
+};
+
+function isLocked(c: CommanderAvatar): boolean {
+  return !!(c.lockedUntil && Date.now() < c.lockedUntil);
+}
+
+function lockRemaining(c: CommanderAvatar): string {
+  if (!c.lockedUntil) return "";
+  const ms = c.lockedUntil - Date.now();
+  if (ms <= 0) return "";
+  const h = Math.floor(ms / 3600000);
+  const m = Math.floor((ms % 3600000) / 60000);
+  return h > 0 ? `${h}h ${m}m` : `${m}m`;
 }
 
 export function AttackModal({
@@ -28,8 +60,13 @@ export function AttackModal({
   const [troops, setTroops] = useState(1);
   const [extraIron, setExtraIron] = useState(0);
   const [extraFuel, setExtraFuel] = useState(0);
+  const [selectedCommanderId, setSelectedCommanderId] = useState<string | null>(null);
 
   if (!targetParcel || !attacker) return null;
+
+  const commanders: CommanderAvatar[] = attacker.commanders ?? [];
+  const selectedCommander = commanders.find((c) => c.id === selectedCommanderId) ?? null;
+  const battleDurationMin = Math.round(BATTLE_DURATION_MS / 60000);
 
   const baseCost = {
     iron: ATTACK_BASE_COST.iron * troops,
@@ -48,17 +85,18 @@ export function AttackModal({
     Math.floor(attacker.fuel / ATTACK_BASE_COST.fuel)
   );
 
-  const attackerPower = troops * 10 + extraIron * 0.5 + extraFuel * 0.8;
+  const commanderBonus = selectedCommander?.attackBonus ?? 0;
+  const attackerPower = troops * 10 + extraIron * 0.5 + extraFuel * 0.8 + commanderBonus;
   const defenderPower = targetParcel.defenseLevel * 15 * biomeBonuses[targetParcel.biome].defenseMod;
   const winChance = Math.min(95, Math.max(5, (attackerPower / (attackerPower + defenderPower)) * 100));
 
   const handleSubmit = () => {
-    onAttack(troops, totalCost.iron, totalCost.fuel);
+    onAttack(troops, totalCost.iron, totalCost.fuel, selectedCommanderId ?? undefined);
   };
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-md backdrop-blur-md" data-testid="modal-attack">
+      <DialogContent className="sm:max-w-lg backdrop-blur-md max-h-[90vh] overflow-y-auto" data-testid="modal-attack">
         <DialogHeader>
           <DialogTitle className="font-display text-xl uppercase tracking-wide flex items-center gap-2">
             <Swords className="w-5 h-5 text-destructive" />
@@ -69,18 +107,85 @@ export function AttackModal({
           </DialogDescription>
         </DialogHeader>
 
-        <div className="space-y-6 py-4">
-          <div className="p-4 bg-destructive/10 border border-destructive/30 rounded-md">
-            <div className="flex items-center gap-2 text-destructive mb-2">
+        <div className="space-y-5 py-4">
+          {/* Combat Warning */}
+          <div className="p-3 bg-destructive/10 border border-destructive/30 rounded-md">
+            <div className="flex items-center gap-2 text-destructive mb-1.5">
               <AlertTriangle className="w-4 h-4" />
               <span className="font-display text-sm uppercase tracking-wide">Combat Warning</span>
             </div>
-            <p className="text-xs text-muted-foreground">
-              Battle will resolve in 4 hours. Resources are consumed immediately.
-              Outcome is probabilistic based on power levels.
+            <p className="text-xs text-muted-foreground flex items-center gap-1.5">
+              <Clock className="w-3 h-3 shrink-0" />
+              Battle resolves in {battleDurationMin} minutes. Resources consumed immediately.
             </p>
           </div>
 
+          {/* Commander Selection */}
+          {commanders.length > 0 && (
+            <div className="space-y-2">
+              <div className="flex items-center justify-between">
+                <span className="text-sm font-display uppercase tracking-wide">Choose Commander</span>
+                {selectedCommander && (
+                  <Badge variant="outline" className="text-[10px] font-mono">
+                    +{selectedCommander.attackBonus} ATK bonus
+                  </Badge>
+                )}
+              </div>
+              <div className="overflow-x-auto pb-1">
+                <div className="flex gap-2 w-max">
+                  {/* No Commander */}
+                  <button
+                    onClick={() => setSelectedCommanderId(null)}
+                    className={cn(
+                      "flex-shrink-0 w-[72px] h-24 rounded-md border-2 flex flex-col items-center justify-center gap-1 transition-colors",
+                      !selectedCommanderId
+                        ? "border-primary bg-primary/10"
+                        : "border-border bg-muted/20 hover:border-muted-foreground"
+                    )}
+                  >
+                    <Swords className="w-4 h-4 text-muted-foreground" />
+                    <span className="text-[9px] font-display uppercase tracking-wide text-muted-foreground">No Cmd</span>
+                  </button>
+
+                  {commanders.map((c) => {
+                    const locked = isLocked(c);
+                    const selected = selectedCommanderId === c.id;
+                    const Icon = TIER_ICON[c.tier];
+                    return (
+                      <button
+                        key={c.id}
+                        disabled={locked}
+                        onClick={() => !locked && setSelectedCommanderId(selected ? null : c.id)}
+                        className={cn(
+                          "flex-shrink-0 w-[72px] h-24 rounded-md border-2 flex flex-col items-center justify-center gap-0.5 transition-colors relative px-1",
+                          selected
+                            ? TIER_BORDER_SELECTED[c.tier]
+                            : locked
+                            ? "border-border bg-muted/10 opacity-40 cursor-not-allowed"
+                            : "border-border bg-muted/20 hover:border-primary/50"
+                        )}
+                      >
+                        {locked && (
+                          <Lock className="w-3 h-3 text-muted-foreground absolute top-1 right-1" />
+                        )}
+                        <Icon className={cn("w-5 h-5", TIER_COLOR[c.tier])} />
+                        <span className="text-[9px] font-display uppercase tracking-wide leading-tight text-center line-clamp-1">
+                          {c.name}
+                        </span>
+                        {locked ? (
+                          <span className="text-[8px] text-destructive/70 font-mono">{lockRemaining(c)}</span>
+                        ) : (
+                          <span className="text-[8px] text-muted-foreground font-mono">+{c.attackBonus} ATK</span>
+                        )}
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* Troops */}
           <div className="space-y-4">
             <div>
               <div className="flex items-center justify-between mb-2">
@@ -157,17 +262,28 @@ export function AttackModal({
             </div>
           </div>
 
+          {/* Power Display */}
           <div className="grid grid-cols-2 gap-4 p-4 bg-card border border-border rounded-md">
             <div data-testid="display-attacker-power">
               <p className="text-xs text-muted-foreground uppercase font-display tracking-wide mb-1">Your Power</p>
-              <p className="font-mono text-2xl font-bold text-primary" data-testid="text-attacker-power">{Math.round(attackerPower)}</p>
+              <p className="font-mono text-2xl font-bold text-primary" data-testid="text-attacker-power">
+                {Math.round(attackerPower)}
+              </p>
+              {commanderBonus > 0 && (
+                <p className="text-[10px] text-muted-foreground">
+                  incl. +{commanderBonus} from commander
+                </p>
+              )}
             </div>
             <div data-testid="display-defender-power">
               <p className="text-xs text-muted-foreground uppercase font-display tracking-wide mb-1">Defender Power</p>
-              <p className="font-mono text-2xl font-bold text-destructive" data-testid="text-defender-power">{Math.round(defenderPower)}</p>
+              <p className="font-mono text-2xl font-bold text-destructive" data-testid="text-defender-power">
+                {Math.round(defenderPower)}
+              </p>
             </div>
           </div>
 
+          {/* Win Chance */}
           <div className="flex items-center justify-between p-3 bg-muted rounded-md" data-testid="display-win-chance">
             <span className="text-sm font-display uppercase tracking-wide">Win Chance</span>
             <Badge
@@ -179,6 +295,7 @@ export function AttackModal({
             </Badge>
           </div>
 
+          {/* Total Cost */}
           <div className="flex items-center justify-between text-sm">
             <span className="text-muted-foreground font-display uppercase tracking-wide">Total Cost</span>
             <div className="flex items-center gap-3">

--- a/client/src/components/game/BattleWatchModal.tsx
+++ b/client/src/components/game/BattleWatchModal.tsx
@@ -1,0 +1,315 @@
+import { useState, useEffect, useRef } from "react";
+import { Swords, Shield, Zap, Skull, Crosshair, Target, Clock, Trophy, X } from "lucide-react";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Progress } from "@/components/ui/progress";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import type { Battle, Player, CommanderAvatar } from "@shared/schema";
+import { COMMANDER_INFO } from "@shared/schema";
+
+// ── Deterministic seeded event generation ─────────────────────────────────
+
+function hashCode(str: string): number {
+  let h = 0;
+  for (let i = 0; i < str.length; i++) {
+    h = Math.imul(31, h) + str.charCodeAt(i) | 0;
+  }
+  return Math.abs(h);
+}
+
+interface BattleEvent {
+  id: number;
+  ts: number;
+  text: string;
+  side: "attacker" | "defender" | "neutral";
+}
+
+function generateEvents(
+  battle: Battle,
+  attackerName: string,
+  defenderName: string,
+  commanderTier?: string,
+): BattleEvent[] {
+  const attackerAhead = battle.attackerPower > battle.defenderPower;
+  const duration = battle.resolveTs - battle.startTs;
+
+  // Commander-flavored openers
+  const commanderLine: Record<string, string> = {
+    sentinel: `${attackerName}'s Sentinel establishes a fortified advance line`,
+    phantom: `${attackerName}'s Phantom activates cloaking field — forces vanish from radar`,
+    reaper: `${attackerName}'s Reaper triggers Annihilate protocol — all cannons open fire`,
+  };
+
+  const attackerPool = [
+    commanderTier ? commanderLine[commanderTier] : null,
+    `${attackerName} launches a missile barrage at the eastern wall`,
+    `Armored column breaches the outer perimeter`,
+    `Strike team advances under suppressive fire`,
+    `${attackerName} hits the fuel depot — enemy supply lines cut`,
+    `Forward operating base secured inside the defensive line`,
+    `Iron stockpile targeted by precision artillery`,
+    `Assault drones deployed over the contested zone`,
+    `Alpha squad secures the north gate`,
+    `${attackerName} calls in orbital targeting coordinates`,
+  ].filter(Boolean) as string[];
+
+  const defenderPool = [
+    `Emergency bunkers reinforced along the perimeter`,
+    `${defenderName}'s turret grid engages — incoming troops taking losses`,
+    `Counter-strike repels the assault — attackers pushed back`,
+    `Shield generator absorbs a direct hit`,
+    `Reinforcements arrive — defensive line holds firm`,
+    `Radar detects flanking maneuver — ambush prepared`,
+    `${defenderName} seals the breach under fire`,
+    `Anti-air battery lights up the drone swarm`,
+    `${defenderName} activates fortress lockdown`,
+  ];
+
+  const neutralPool = [
+    `Artillery exchange — heavy losses on both sides`,
+    `Communication blackout — both commanders go dark`,
+    `Smoke screen deployed — ground forces repositioning`,
+    `Supply convoy ambushed — both sides short on fuel`,
+    `Recon drone spotted — electronic warfare begins`,
+    `Satellite feed disrupted — commanders flying blind`,
+  ];
+
+  const events: BattleEvent[] = [];
+  let rng = hashCode(battle.id);
+
+  const next = (): number => {
+    rng = (rng * 1664525 + 1013904223) >>> 0;
+    return rng;
+  };
+
+  const NUM_EVENTS = 8;
+  for (let i = 0; i < NUM_EVENTS; i++) {
+    const r1 = next();
+    const r2 = next();
+    const r3 = next();
+    const timeOffset = (duration / (NUM_EVENTS + 1)) * (i + 1);
+    const ts = battle.startTs + timeOffset;
+
+    const rand = r1 % 100;
+    let side: BattleEvent["side"];
+    let text: string;
+
+    if (attackerAhead) {
+      if (rand < 52) {
+        side = "attacker";
+        text = attackerPool[r2 % attackerPool.length];
+      } else if (rand < 82) {
+        side = "defender";
+        text = defenderPool[r2 % defenderPool.length];
+      } else {
+        side = "neutral";
+        text = neutralPool[r3 % neutralPool.length];
+      }
+    } else {
+      if (rand < 52) {
+        side = "defender";
+        text = defenderPool[r2 % defenderPool.length];
+      } else if (rand < 82) {
+        side = "attacker";
+        text = attackerPool[r2 % attackerPool.length];
+      } else {
+        side = "neutral";
+        text = neutralPool[r3 % neutralPool.length];
+      }
+    }
+
+    events.push({ id: i, ts, text, side });
+  }
+
+  return events;
+}
+
+// ── Component ──────────────────────────────────────────────────────────────
+
+interface BattleWatchModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  battle: Battle | null;
+  players: Player[];
+}
+
+export function BattleWatchModal({ open, onOpenChange, battle, players }: BattleWatchModalProps) {
+  const [now, setNow] = useState(() => Date.now());
+  const feedRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const id = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(id);
+  }, [open]);
+
+  if (!battle) return null;
+
+  const attacker = players.find((p) => p.id === battle.attackerId);
+  const defender = players.find((p) => p.id === battle.defenderId);
+  const attackerName = attacker?.name ?? "Attacker";
+  const defenderName = defender?.name ?? "Defender";
+
+  // Find which commander was used
+  const usedCommander: CommanderAvatar | undefined = battle.commanderId
+    ? attacker?.commanders?.find((c) => c.id === battle.commanderId)
+    : undefined;
+  const commanderTier = usedCommander?.tier;
+
+  const events = generateEvents(battle, attackerName, defenderName, commanderTier);
+  const visibleEvents = events.filter((e) => now >= e.ts);
+
+  const elapsed = now - battle.startTs;
+  const totalDuration = battle.resolveTs - battle.startTs;
+  const progress = Math.min(100, (elapsed / totalDuration) * 100);
+  const remaining = Math.max(0, battle.resolveTs - now);
+  const isResolved = battle.status === "resolved";
+  const timerExpired = now >= battle.resolveTs;
+
+  const formatTime = (ms: number) => {
+    const m = Math.floor(ms / 60000);
+    const s = Math.floor((ms % 60000) / 1000);
+    return `${m}:${s.toString().padStart(2, "0")}`;
+  };
+
+  const attackerWins = battle.outcome === "attacker_wins";
+  const defenderWins = battle.outcome === "defender_wins";
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-2xl max-h-[92vh] flex flex-col backdrop-blur-md p-0 gap-0 overflow-hidden">
+        {/* Header */}
+        <DialogHeader className="px-6 pt-5 pb-0">
+          <DialogTitle className="font-display text-xl uppercase tracking-wide flex items-center gap-2">
+            <Swords className={cn("w-5 h-5", !timerExpired && "text-destructive animate-pulse", timerExpired && "text-muted-foreground")} />
+            {isResolved ? "Battle Resolved" : timerExpired ? "Awaiting Resolution..." : "Battle Live"}
+          </DialogTitle>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-4 p-6 overflow-y-auto flex-1">
+          {/* VS Panel */}
+          <div className="grid grid-cols-3 items-center gap-3 p-4 bg-card border border-border rounded-md">
+            <div className="text-center space-y-1">
+              <p className="font-display text-xs uppercase tracking-wide text-muted-foreground">Attacker</p>
+              <p className="font-display text-sm font-bold text-primary truncate">{attackerName}</p>
+              {usedCommander && (
+                <Badge variant="outline" className="text-[9px] gap-1">
+                  {usedCommander.tier === "sentinel" && <Shield className="w-2.5 h-2.5 text-blue-400" />}
+                  {usedCommander.tier === "phantom" && <Zap className="w-2.5 h-2.5 text-purple-400" />}
+                  {usedCommander.tier === "reaper" && <Skull className="w-2.5 h-2.5 text-red-400" />}
+                  {usedCommander.name}
+                </Badge>
+              )}
+              <p className="font-mono text-2xl font-bold text-primary">{Math.round(battle.attackerPower)}</p>
+              <p className="text-[10px] text-muted-foreground uppercase tracking-wide">Power</p>
+            </div>
+
+            <div className="flex flex-col items-center gap-1">
+              <Swords className="w-8 h-8 text-destructive" />
+              <span className="font-display text-xs text-muted-foreground">VS</span>
+              <span className="font-display text-[10px] uppercase text-muted-foreground">Plot #{battle.targetParcelId.slice(0, 4)}</span>
+            </div>
+
+            <div className="text-center space-y-1">
+              <p className="font-display text-xs uppercase tracking-wide text-muted-foreground">Defender</p>
+              <p className="font-display text-sm font-bold text-destructive truncate">{defenderName}</p>
+              <div className="h-5" />
+              <p className="font-mono text-2xl font-bold text-destructive">{Math.round(battle.defenderPower)}</p>
+              <p className="text-[10px] text-muted-foreground uppercase tracking-wide">Power</p>
+            </div>
+          </div>
+
+          {/* Timer */}
+          <div className="space-y-1.5">
+            <div className="flex items-center justify-between text-xs">
+              <span className="text-muted-foreground flex items-center gap-1">
+                <Clock className="w-3 h-3" />
+                {isResolved ? "Complete" : timerExpired ? "Processing..." : "Battle progress"}
+              </span>
+              <span className="font-mono text-muted-foreground">
+                {isResolved || timerExpired ? "—" : formatTime(remaining) + " remaining"}
+              </span>
+            </div>
+            <Progress
+              value={progress}
+              className={cn("h-2", isResolved && attackerWins && "[&>div]:bg-primary", isResolved && defenderWins && "[&>div]:bg-destructive")}
+            />
+          </div>
+
+          {/* Battle Feed */}
+          <div className="border border-border rounded-md overflow-hidden flex-1 min-h-[200px]">
+            <div className="px-3 py-2 border-b border-border bg-muted/30">
+              <p className="text-[10px] font-display uppercase tracking-wide text-muted-foreground">Battle Log</p>
+            </div>
+            <div ref={feedRef} className="p-3 space-y-2 max-h-64 overflow-y-auto">
+              {visibleEvents.length === 0 && (
+                <p className="text-xs text-muted-foreground text-center py-6 italic">
+                  Forces advancing... battle commencing
+                </p>
+              )}
+              {[...visibleEvents].reverse().map((event, idx) => (
+                <div
+                  key={event.id}
+                  className={cn(
+                    "flex items-start gap-2 p-2.5 rounded-md text-xs border transition-all",
+                    idx === 0 && "ring-1 ring-offset-1",
+                    event.side === "attacker" && "bg-primary/5 border-primary/20",
+                    event.side === "attacker" && idx === 0 && "ring-primary/30",
+                    event.side === "defender" && "bg-destructive/5 border-destructive/20",
+                    event.side === "defender" && idx === 0 && "ring-destructive/30",
+                    event.side === "neutral" && "bg-muted/20 border-border",
+                    event.side === "neutral" && idx === 0 && "ring-border",
+                  )}
+                >
+                  <div className="mt-0.5 shrink-0">
+                    {event.side === "attacker" && <Crosshair className="w-3 h-3 text-primary" />}
+                    {event.side === "defender" && <Shield className="w-3 h-3 text-destructive" />}
+                    {event.side === "neutral" && <Target className="w-3 h-3 text-muted-foreground" />}
+                  </div>
+                  <p className="leading-snug">{event.text}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Outcome Banner */}
+          {isResolved && battle.outcome && (
+            <div
+              className={cn(
+                "p-5 rounded-md text-center border space-y-1",
+                attackerWins ? "bg-primary/10 border-primary/40" : "bg-destructive/10 border-destructive/40",
+              )}
+            >
+              <div className="flex items-center justify-center gap-2">
+                <Trophy className={cn("w-6 h-6", attackerWins ? "text-primary" : "text-destructive")} />
+                <p className={cn("font-display text-2xl uppercase tracking-widest", attackerWins ? "text-primary" : "text-destructive")}>
+                  {attackerWins ? "Victory" : "Defeat"}
+                </p>
+              </div>
+              <p className="text-sm text-muted-foreground">
+                {attackerWins
+                  ? `${attackerName} has captured the territory`
+                  : `${defenderName} repelled the attack`}
+              </p>
+            </div>
+          )}
+
+          {timerExpired && !isResolved && (
+            <div className="p-3 rounded-md text-center border border-border bg-muted/20">
+              <p className="text-xs text-muted-foreground">Waiting for server to resolve battle...</p>
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="px-6 pb-5">
+          <Button variant="outline" onClick={() => onOpenChange(false)} className="w-full font-display uppercase tracking-wide">
+            <X className="w-4 h-4 mr-2" />
+            Close
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/client/src/components/game/BattlesPanel.tsx
+++ b/client/src/components/game/BattlesPanel.tsx
@@ -1,5 +1,6 @@
-import { Swords, Clock, User, Bot, ChevronRight, AlertTriangle, CheckCircle2 } from "lucide-react";
+import { Swords, Clock, User, Bot, ChevronRight, AlertTriangle, CheckCircle2, Eye } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Progress } from "@/components/ui/progress";
 import { cn } from "@/lib/utils";
@@ -9,10 +10,19 @@ interface BattlesPanelProps {
   battles: Battle[];
   events: GameEvent[];
   players: Player[];
+  onWatchBattle?: (battleId: string) => void;
   className?: string;
 }
 
-function BattleCard({ battle, players }: { battle: Battle; players: Player[] }) {
+function BattleCard({
+  battle,
+  players,
+  onWatch,
+}: {
+  battle: Battle;
+  players: Player[];
+  onWatch?: (id: string) => void;
+}) {
   const attacker = players.find((p) => p.id === battle.attackerId);
   const defender = players.find((p) => p.id === battle.defenderId);
   const now = Date.now();
@@ -37,14 +47,22 @@ function BattleCard({ battle, players }: { battle: Battle; players: Player[] }) 
     >
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
-          <Swords className={cn(
-            "w-4 h-4",
-            battle.status === "pending" ? "text-destructive animate-pulse" : "text-muted-foreground"
-          )} />
+          <Swords
+            className={cn(
+              "w-4 h-4",
+              battle.status === "pending" ? "text-destructive animate-pulse" : "text-muted-foreground"
+            )}
+          />
           <span className="font-display text-xs uppercase tracking-wide">#{battle.id.slice(0, 6)}</span>
         </div>
         <Badge
-          variant={battle.status === "pending" ? "destructive" : battle.outcome === "attacker_wins" ? "default" : "secondary"}
+          variant={
+            battle.status === "pending"
+              ? "destructive"
+              : battle.outcome === "attacker_wins"
+              ? "default"
+              : "secondary"
+          }
           className="text-[10px]"
         >
           {battle.status === "pending" ? "LIVE" : battle.outcome === "attacker_wins" ? "WON" : "LOST"}
@@ -66,7 +84,9 @@ function BattleCard({ battle, players }: { battle: Battle; players: Player[] }) 
       {battle.status === "pending" && (
         <div className="space-y-1">
           <div className="flex items-center justify-between text-[10px] text-muted-foreground">
-            <span className="flex items-center gap-1"><Clock className="w-2.5 h-2.5" /> Resolves in</span>
+            <span className="flex items-center gap-1">
+              <Clock className="w-2.5 h-2.5" /> Resolves in
+            </span>
             <span className="font-mono">{formatTime(remaining)}</span>
           </div>
           <Progress value={progress} className="h-1" />
@@ -74,9 +94,25 @@ function BattleCard({ battle, players }: { battle: Battle; players: Player[] }) 
       )}
 
       <div className="flex items-center justify-between text-[10px] text-muted-foreground">
-        <span>ATK <span className="font-mono text-foreground">{Math.round(battle.attackerPower)}</span></span>
-        <span>DEF <span className="font-mono text-foreground">{Math.round(battle.defenderPower)}</span></span>
+        <span>
+          ATK <span className="font-mono text-foreground">{Math.round(battle.attackerPower)}</span>
+        </span>
+        <span>
+          DEF <span className="font-mono text-foreground">{Math.round(battle.defenderPower)}</span>
+        </span>
       </div>
+
+      {onWatch && (
+        <Button
+          variant="outline"
+          size="sm"
+          className="w-full h-7 text-[10px] font-display uppercase tracking-wide gap-1.5"
+          onClick={() => onWatch(battle.id)}
+        >
+          <Eye className="w-3 h-3" />
+          Watch Battle
+        </Button>
+      )}
     </div>
   );
 }
@@ -84,14 +120,22 @@ function BattleCard({ battle, players }: { battle: Battle; players: Player[] }) 
 function EventItem({ event }: { event: GameEvent }) {
   const icon = (() => {
     switch (event.type) {
-      case "mine": return <div className="w-2 h-2 rounded-full bg-iron" />;
-      case "upgrade": return <div className="w-2 h-2 rounded-full bg-fuel" />;
-      case "build": return <div className="w-2 h-2 rounded-full bg-primary" />;
-      case "purchase": return <div className="w-2 h-2 rounded-full bg-primary" />;
-      case "attack": return <div className="w-2 h-2 rounded-full bg-destructive" />;
-      case "battle_resolved": return <CheckCircle2 className="w-3 h-3 text-primary" />;
-      case "ai_action": return <Bot className="w-3 h-3 text-muted-foreground" />;
-      default: return <div className="w-2 h-2 rounded-full bg-muted" />;
+      case "mine":
+        return <div className="w-2 h-2 rounded-full bg-iron" />;
+      case "upgrade":
+        return <div className="w-2 h-2 rounded-full bg-fuel" />;
+      case "build":
+        return <div className="w-2 h-2 rounded-full bg-primary" />;
+      case "purchase":
+        return <div className="w-2 h-2 rounded-full bg-primary" />;
+      case "attack":
+        return <div className="w-2 h-2 rounded-full bg-destructive" />;
+      case "battle_resolved":
+        return <CheckCircle2 className="w-3 h-3 text-primary" />;
+      case "ai_action":
+        return <Bot className="w-3 h-3 text-muted-foreground" />;
+      default:
+        return <div className="w-2 h-2 rounded-full bg-muted" />;
     }
   })();
 
@@ -101,7 +145,10 @@ function EventItem({ event }: { event: GameEvent }) {
   };
 
   return (
-    <div className="flex items-start gap-2.5 py-1.5 border-b border-border/20 last:border-0" data-testid={`event-${event.id}`}>
+    <div
+      className="flex items-start gap-2.5 py-1.5 border-b border-border/20 last:border-0"
+      data-testid={`event-${event.id}`}
+    >
       <div className="mt-1.5 shrink-0">{icon}</div>
       <div className="flex-1 min-w-0">
         <p className="text-xs text-foreground leading-tight">{event.description}</p>
@@ -111,10 +158,12 @@ function EventItem({ event }: { event: GameEvent }) {
   );
 }
 
-export function BattlesPanel({ battles, events, players, className }: BattlesPanelProps) {
+export function BattlesPanel({ battles, events, players, onWatchBattle, className }: BattlesPanelProps) {
   const activeBattles = battles.filter((b) => b.status === "pending");
   const recentBattles = battles.filter((b) => b.status === "resolved").slice(0, 10);
-  const battleEvents = events.filter(e => ["attack", "battle_resolved"].includes(e.type)).slice(0, 20);
+  const battleEvents = events
+    .filter((e) => ["attack", "battle_resolved"].includes(e.type))
+    .slice(0, 20);
 
   return (
     <div className={cn("flex flex-col h-full", className)} data-testid="battles-panel">
@@ -135,21 +184,31 @@ export function BattlesPanel({ battles, events, players, className }: BattlesPan
               <h3 className="text-[10px] font-display uppercase tracking-wide text-destructive flex items-center gap-1.5">
                 <AlertTriangle className="w-3 h-3" /> Active Battles
               </h3>
-              {activeBattles.map((b) => <BattleCard key={b.id} battle={b} players={players} />)}
+              {activeBattles.map((b) => (
+                <BattleCard key={b.id} battle={b} players={players} onWatch={onWatchBattle} />
+              ))}
             </div>
           )}
 
           {recentBattles.length > 0 && (
             <div className="space-y-2">
-              <h3 className="text-[10px] font-display uppercase tracking-wide text-muted-foreground">Recent Battles</h3>
-              {recentBattles.map((b) => <BattleCard key={b.id} battle={b} players={players} />)}
+              <h3 className="text-[10px] font-display uppercase tracking-wide text-muted-foreground">
+                Recent Battles
+              </h3>
+              {recentBattles.map((b) => (
+                <BattleCard key={b.id} battle={b} players={players} onWatch={onWatchBattle} />
+              ))}
             </div>
           )}
 
           {battleEvents.length > 0 && (
             <div className="space-y-1">
-              <h3 className="text-[10px] font-display uppercase tracking-wide text-muted-foreground">Battle Log</h3>
-              {battleEvents.map((e) => <EventItem key={e.id} event={e} />)}
+              <h3 className="text-[10px] font-display uppercase tracking-wide text-muted-foreground">
+                Battle Log
+              </h3>
+              {battleEvents.map((e) => (
+                <EventItem key={e.id} event={e} />
+              ))}
             </div>
           )}
 

--- a/client/src/components/game/GameLayout.tsx
+++ b/client/src/components/game/GameLayout.tsx
@@ -3,6 +3,7 @@ import { TopBar } from "./TopBar";
 import { ResourceHUD } from "./ResourceHUD";
 import { FlatMap } from "./FlatMap";
 import { AttackModal } from "./AttackModal";
+import { BattleWatchModal } from "./BattleWatchModal";
 import { BottomNav, type NavTab } from "./BottomNav";
 import { LandSheet } from "./LandSheet";
 import { InventoryPanel } from "./InventoryPanel";
@@ -72,6 +73,7 @@ export function GameLayout() {
 
   const [selectedParcelId, setSelectedParcelId] = useState<string | null>(null);
   const [attackModalOpen, setAttackModalOpen] = useState(false);
+  const [watchingBattleId, setWatchingBattleId] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState<NavTab>("map");
   const [showOnboarding, setShowOnboarding] = useState(false);
   const [showGamerTag, setShowGamerTag] = useState(false);
@@ -170,16 +172,18 @@ export function GameLayout() {
 
   const handleAttackClick = () => setAttackModalOpen(true);
 
-  const handleAttackConfirm = async (troops: number, iron: number, fuel: number) => {
+  const handleAttackConfirm = async (troops: number, iron: number, fuel: number, commanderId?: string) => {
     if (!player || !selectedParcelId || !selectedParcel) return;
     // Log to chain (batched, fire-and-forget)
     queueAttackAction(selectedParcel.plotId, troops, iron, fuel);
     attackMutation.mutate(
-      { attackerId: player.id, targetParcelId: selectedParcelId, troopsCommitted: troops, resourcesBurned: { iron, fuel } },
+      { attackerId: player.id, targetParcelId: selectedParcelId, troopsCommitted: troops, resourcesBurned: { iron, fuel }, commanderId },
       {
-        onSuccess: () => {
+        onSuccess: (data: any) => {
+          const battleId = data?.id as string | undefined;
           toast({ title: "Attack Deployed", description: "Battle will resolve in 10 minutes." });
           setAttackModalOpen(false);
+          if (battleId) setWatchingBattleId(battleId);
         },
         onError: (error) => toast({ title: "Attack Failed", description: error.message, variant: "destructive" }),
       }
@@ -525,6 +529,7 @@ export function GameLayout() {
             battles={gameState.battles}
             events={gameState.events}
             players={gameState.players}
+            onWatchBattle={setWatchingBattleId}
             className="h-full border-0 rounded-none"
           />
         ) : null}
@@ -548,6 +553,7 @@ export function GameLayout() {
               battles={gameState.battles}
               events={gameState.events}
               players={gameState.players}
+              onWatchBattle={setWatchingBattleId}
             />
           )}
           {activeTab === "commander" && gameState && (
@@ -602,6 +608,13 @@ export function GameLayout() {
         attacker={player}
         onAttack={handleAttackConfirm}
         isAttacking={attackMutation.isPending}
+      />
+
+      <BattleWatchModal
+        open={!!watchingBattleId}
+        onOpenChange={(o) => { if (!o) setWatchingBattleId(null); }}
+        battle={watchingBattleId ? (gameState?.battles.find((b) => b.id === watchingBattleId) ?? null) : null}
+        players={gameState?.players ?? []}
       />
     </div>
   );

--- a/client/src/components/game/WarRoomPanel.tsx
+++ b/client/src/components/game/WarRoomPanel.tsx
@@ -1,5 +1,6 @@
-import { Swords, Clock, User, Bot, ChevronRight, AlertTriangle, CheckCircle2, XCircle, TrendingDown, ShieldOff } from "lucide-react";
+import { Swords, Clock, User, Bot, ChevronRight, AlertTriangle, CheckCircle2, XCircle, TrendingDown, ShieldOff, Eye } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Progress } from "@/components/ui/progress";
@@ -11,10 +12,11 @@ interface WarRoomPanelProps {
   battles: Battle[];
   events: GameEvent[];
   players: Player[];
+  onWatchBattle?: (battleId: string) => void;
   className?: string;
 }
 
-function BattleCard({ battle, players }: { battle: Battle; players: Player[] }) {
+function BattleCard({ battle, players, onWatch }: { battle: Battle; players: Player[]; onWatch?: (id: string) => void }) {
   const attacker = players.find((p) => p.id === battle.attackerId);
   const defender = players.find((p) => p.id === battle.defenderId);
   const now = Date.now();
@@ -22,11 +24,11 @@ function BattleCard({ battle, players }: { battle: Battle; players: Player[] }) 
   const totalDuration = battle.resolveTs - battle.startTs;
   const progress = Math.min(100, (elapsed / totalDuration) * 100);
   const remaining = Math.max(0, battle.resolveTs - now);
-  
+
   const formatTime = (ms: number) => {
-    const hours = Math.floor(ms / 3600000);
-    const minutes = Math.floor((ms % 3600000) / 60000);
-    return `${hours}h ${minutes}m`;
+    const minutes = Math.floor(ms / 60000);
+    const seconds = Math.floor((ms % 60000) / 1000);
+    return `${minutes}m ${seconds}s`;
   };
 
   return (
@@ -76,12 +78,24 @@ function BattleCard({ battle, players }: { battle: Battle; players: Player[] }) 
 
       <div className="flex items-center justify-between text-xs">
         <span className="text-muted-foreground">
-          Power: <span className="font-mono text-foreground">{battle.attackerPower}</span> vs <span className="font-mono text-foreground">{battle.defenderPower}</span>
+          Power: <span className="font-mono text-foreground">{Math.round(battle.attackerPower)}</span> vs <span className="font-mono text-foreground">{Math.round(battle.defenderPower)}</span>
         </span>
         <span className="text-muted-foreground">
           Target: <span className="font-mono text-foreground">{battle.targetParcelId.slice(0, 8)}</span>
         </span>
       </div>
+
+      {onWatch && (
+        <Button
+          variant="outline"
+          size="sm"
+          className="w-full h-7 text-[10px] font-display uppercase tracking-wide gap-1.5"
+          onClick={() => onWatch(battle.id)}
+        >
+          <Eye className="w-3 h-3" />
+          Watch Battle
+        </Button>
+      )}
     </div>
   );
 }
@@ -186,7 +200,7 @@ function AIActivityFeed({ players, events }: { players: Player[]; events: GameEv
   );
 }
 
-export function WarRoomPanel({ battles, events, players, className }: WarRoomPanelProps) {
+export function WarRoomPanel({ battles, events, players, onWatchBattle, className }: WarRoomPanelProps) {
   const activeBattles = battles.filter((b) => b.status === "pending");
   const recentBattles = battles.filter((b) => b.status === "resolved").slice(0, 5);
   const recentEvents = events.slice(0, 15);
@@ -241,13 +255,13 @@ export function WarRoomPanel({ battles, events, players, className }: WarRoomPan
               ) : (
                 <>
                   {activeBattles.map((battle) => (
-                    <BattleCard key={battle.id} battle={battle} players={players} />
+                    <BattleCard key={battle.id} battle={battle} players={players} onWatch={onWatchBattle} />
                   ))}
                   {recentBattles.length > 0 && (
                     <>
                       <p className="text-xs text-muted-foreground uppercase font-display tracking-wide pt-2">Recent</p>
                       {recentBattles.map((battle) => (
-                        <BattleCard key={battle.id} battle={battle} players={players} />
+                        <BattleCard key={battle.id} battle={battle} players={players} onWatch={onWatchBattle} />
                       ))}
                     </>
                   )}

--- a/server/db-schema.ts
+++ b/server/db-schema.ts
@@ -141,6 +141,7 @@ export const battles = pgTable(
     status:           varchar("status", { length: 20 }).notNull().default("pending"),
     outcome:          varchar("outcome", { length: 20 }),
     randFactor:       real("rand_factor"),
+    commanderId:      varchar("commander_id", { length: 36 }),
   },
   (t) => ({
     /** Used by resolveBattles() to efficiently find pending battles past their resolveTs. */

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -55,6 +55,7 @@ import {
   ATTACK_COOLDOWN_PER_LOSS_MS,
   PILLAGE_RATE,
   CASCADE_DEFENSE_PENALTY,
+  COMMANDER_LOCK_MS,
 } from "@shared/schema";
 import type { FacilityType, DefenseImprovementType } from "@shared/schema";
 import { generateFibonacciSphere, sphereDistance, type PlotCoord } from "./sphereUtils";
@@ -744,9 +745,24 @@ export class MemStorage implements IStorage {
     attacker.iron -= totalIron;
     attacker.fuel -= totalFuel;
 
-    const rawAttackerPower = action.troopsCommitted * 10 + totalIron * 0.5 + totalFuel * 0.8;
-    // Apply morale debuff: reduces attack power when attacker has recently lost territory
+    // Resolve commander: validate availability and apply attack bonus
     const now = Date.now();
+    let commanderBonus = 0;
+    let commanderId: string | undefined;
+    if (action.commanderId) {
+      const cmdIdx = attacker.commanders.findIndex((c) => c.id === action.commanderId);
+      if (cmdIdx === -1) throw new Error("Commander not found");
+      const cmd = attacker.commanders[cmdIdx];
+      if (cmd.lockedUntil && now < cmd.lockedUntil) throw new Error("Commander is currently deployed and unavailable");
+      commanderBonus = cmd.attackBonus;
+      commanderId = cmd.id;
+      // Lock commander for 12 hours
+      attacker.commanders[cmdIdx] = { ...cmd, lockedUntil: now + COMMANDER_LOCK_MS };
+      cmd.totalKills; // no-op, just referencing for type safety
+    }
+
+    const rawAttackerPower = action.troopsCommitted * 10 + totalIron * 0.5 + totalFuel * 0.8 + commanderBonus;
+    // Apply morale debuff: reduces attack power when attacker has recently lost territory
     const moraleActive = attacker.moraleDebuffUntil && now < attacker.moraleDebuffUntil;
     const attackerPower = moraleActive
       ? rawAttackerPower * (1 - MORALE_ATTACK_PENALTY)
@@ -772,6 +788,7 @@ export class MemStorage implements IStorage {
       startTs: now,
       resolveTs: now + BATTLE_DURATION_MS,
       status: "pending",
+      commanderId,
     };
 
     this.battles.set(battleId, battle);
@@ -1363,6 +1380,7 @@ function rowToBattle(row: BattleRow): Battle {
     status:           row.status as "pending" | "resolved",
     outcome:          (row.outcome ?? undefined) as Battle["outcome"],
     randFactor:       row.randFactor ?? undefined,
+    commanderId:      (row as any).commanderId ?? undefined,
   };
 }
 
@@ -2142,8 +2160,23 @@ export class DbStorage implements IStorage {
       const { iron, fuel } = action.resourcesBurned;
       if (attacker.iron < iron || attacker.fuel < fuel) throw new Error("Insufficient resources for attack");
 
-      const now            = Date.now();
-      const rawAttackerPower = action.troopsCommitted * 10 + iron * 0.5 + fuel * 0.8;
+      const now = Date.now();
+
+      // Resolve commander: validate availability and apply attack bonus
+      let commanderBonus = 0;
+      let commanderId: string | undefined;
+      const commanders = (attackerRow.commanders ?? []) as CommanderAvatar[];
+      if (action.commanderId) {
+        const cmdIdx = commanders.findIndex((c) => c.id === action.commanderId);
+        if (cmdIdx === -1) throw new Error("Commander not found");
+        const cmd = commanders[cmdIdx];
+        if (cmd.lockedUntil && now < cmd.lockedUntil) throw new Error("Commander is currently deployed and unavailable");
+        commanderBonus = cmd.attackBonus;
+        commanderId = cmd.id;
+        commanders[cmdIdx] = { ...cmd, lockedUntil: now + COMMANDER_LOCK_MS };
+      }
+
+      const rawAttackerPower = action.troopsCommitted * 10 + iron * 0.5 + fuel * 0.8 + commanderBonus;
       // Apply morale debuff: attacker power is reduced when they recently lost territory
       const moraleActive   = attacker.moraleDebuffUntil && now < attacker.moraleDebuffUntil;
       const attackerPower  = moraleActive
@@ -2170,14 +2203,16 @@ export class DbStorage implements IStorage {
         startTs:          now,
         resolveTs:        now + BATTLE_DURATION_MS,
         status:           "pending" as const,
+        commanderId:      commanderId ?? null,
       };
+
+      const playerUpdates: Record<string, any> = { iron: attackerRow.iron - iron, fuel: attackerRow.fuel - fuel };
+      if (commanderId) playerUpdates.commanders = commanders;
 
       await Promise.all([
         tx.insert(battlesTable).values(battleValues),
         tx.update(parcelsTable).set({ activeBattleId: battleId }).where(eq(parcelsTable.id, target.id)),
-        tx.update(playersTable)
-          .set({ iron: attackerRow.iron - iron, fuel: attackerRow.fuel - fuel })
-          .where(eq(playersTable.id, attacker.id)),
+        tx.update(playersTable).set(playerUpdates).where(eq(playersTable.id, attacker.id)),
       ]);
 
       await this.addEvent({
@@ -2190,7 +2225,7 @@ export class DbStorage implements IStorage {
       }, tx);
       await this.bumpLastTs(now, tx);
 
-      return rowToBattle({ ...battleValues, outcome: undefined, randFactor: undefined } as BattleRow);
+      return rowToBattle({ ...battleValues, outcome: undefined, randFactor: undefined, commanderId: commanderId ?? null } as BattleRow);
     });
   }
 

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -180,6 +180,8 @@ export interface Battle {
   status: "pending" | "resolved";
   outcome?: "attacker_wins" | "defender_wins";
   randFactor?: number;
+  /** ID of the commander deployed in this attack */
+  commanderId?: string;
 }
 
 export interface GameEvent {
@@ -239,6 +241,7 @@ export const attackActionSchema = z.object({
     iron: z.number().min(0),
     fuel: z.number().min(0),
   }),
+  commanderId: z.string().optional(),
 });
 
 export const buildActionSchema = z.object({
@@ -297,6 +300,8 @@ export const LAND_PURCHASE_ALGO: Record<BiomeType, number> = {
 
 export type CommanderTier = "sentinel" | "phantom" | "reaper";
 
+export const COMMANDER_LOCK_MS = 12 * 60 * 60 * 1000; // 12 hours per deployment
+
 export interface CommanderAvatar {
   id: string;
   tier: CommanderTier;
@@ -306,6 +311,8 @@ export interface CommanderAvatar {
   specialAbility: string;
   mintedAt: number;
   totalKills: number;
+  /** Timestamp (ms) until which this commander is locked after being deployed in an attack */
+  lockedUntil?: number;
 }
 
 export const COMMANDER_INFO: Record<CommanderTier, {


### PR DESCRIPTION
- AttackModal: add scrollable commander selection row (Sentinel/Phantom/Reaper)
  showing attack bonus, lock status, and 12-hour cooldown countdown; fix
  hardcoded "4 hours" text to dynamic value from BATTLE_DURATION_MS (10 min)
- Commander locking: deployed commanders are locked for 12h (COMMANDER_LOCK_MS);
  lockedUntil field added to CommanderAvatar; applied in both MemStorage and
  DbStorage deployAttack; commander attackBonus added to battle power calc
- Battle interface: add commanderId field; battles table: add commander_id column
- BattleWatchModal (new): full-screen interactive battle animation modal with
  deterministic seeded event feed (8 events, commander-flavored lines), live
  countdown timer, progress bar, VS panel, and outcome banner
- BattlesPanel + WarRoomPanel: add "Watch Battle" button on every battle card;
  WarRoomPanel timer fixed from hours to minutes/seconds format
- GameLayout: wire commanderId through handleAttackConfirm; auto-open watch
  modal on attack deploy; add watchingBattleId state; pass onWatchBattle
  to both BattlesPanel and WarRoomPanel

https://claude.ai/code/session_01A77Ai472Nmjtmv9yHCy4eK