### PR TITLE
fix: resolve TypeScript compile errors in storage.ts and tsconfig

### DIFF
--- a/server/storage.ts
+++ b/server/storage.ts
@@ -212,6 +212,7 @@ export class MemStorage implements IStorage {
       drones: [],
       satellites: [],
       welcomeBonusReceived: false,
+      testnetProgress: [],
     };
     this.players.set(humanPlayerId, humanPlayer);
 
@@ -256,6 +257,7 @@ export class MemStorage implements IStorage {
         drones: [],
         satellites: [],
         welcomeBonusReceived: true,
+        testnetProgress: [],
       };
       this.players.set(aiId, aiPlayer);
 
@@ -2225,7 +2227,7 @@ export class DbStorage implements IStorage {
       }, tx);
       await this.bumpLastTs(now, tx);
 
-      return rowToBattle({ ...battleValues, outcome: undefined, randFactor: undefined, commanderId: commanderId ?? null } as BattleRow);
+      return rowToBattle({ ...battleValues, outcome: null, randFactor: null, commanderId: commanderId ?? null } as BattleRow);
     });
   }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "incremental": true,
     "tsBuildInfoFile": "./node_modules/typescript/tsbuildinfo",
     "noEmit": true,
+    "target": "ES2018",
     "module": "ESNext",
     "strict": true,
     "lib": ["esnext", "dom", "dom.iterable"],


### PR DESCRIPTION
- storage.ts: add testnetProgress: [] to humanPlayer and aiPlayer
  constructors in MemStorage.initialize() (lines ~215, ~259) so the
  required Player.testnetProgress field is always present
- storage.ts: change outcome: undefined / randFactor: undefined to
  outcome: null / randFactor: null in the rowToBattle() call at the
  end of DbStorage.deployAttack() (line ~2228), matching the
  string | null / number | null schema types
- tsconfig.json: add "target": "ES2018" to fix TS2802 MapIterator
  iteration error (Map.values() iteration requires ES2015+ target)

npm run check and npm run build both pass with no TS errors.

https://claude.ai/code/session_01UBNRWoCL4AMLC2bAmF3Dzu