### PR TITLE
fix: ASA opt-in UX — check on-chain state, not server cache

### DIFF
--- a/client/src/components/game/GameLayout.tsx
+++ b/client/src/components/game/GameLayout.tsx
@@ -237,6 +237,10 @@ export function GameLayout() {
 
   const handleClaimFrontier = async () => {
     if (!player || !gameState) return;
+    if (!isOptedInToFrontier) {
+      toast({ title: "Opt-In Required", description: "Opt into FRONTIER ASA before claiming tokens.", variant: "destructive" });
+      return;
+    }
     claimFrontierMutation.mutate(player.id, {
       onSuccess: (data: any) => {
         const amount = data.claimed?.amount || 0;

--- a/client/src/hooks/useBlockchainActions.ts
+++ b/client/src/hooks/useBlockchainActions.ts
@@ -11,7 +11,8 @@ import {
   getCachedTreasuryAddress,
   getCachedAsaId,
   optInToASA,
-  isOptedInToASA,
+  algodClient,
+  hasOptedIn,
   type BatchedAction,
 } from "@/lib/algorand";
 import { useToast } from "@/hooks/use-toast";
@@ -50,15 +51,23 @@ export function useBlockchainActions() {
   }, []);
 
   useEffect(() => {
-    if (address && frontierAsaId) {
-      isOptedInToASA(address, frontierAsaId).then((result) => {
+    if (!address || !frontierAsaId) return;
+    algodClient
+      .accountInformation(address)
+      .do()
+      .then((accountInfo) => {
+        const result = hasOptedIn(accountInfo as Record<string, unknown>, frontierAsaId);
         setIsOptedIn(result);
         if (result) {
           localStorage.setItem("frontier_opted_in", "true");
           localStorage.setItem("frontier_opted_in_address", address);
+        } else {
+          localStorage.removeItem("frontier_opted_in");
         }
+      })
+      .catch(() => {
+        // Keep existing cached state if algod is temporarily unreachable
       });
-    }
   }, [address, frontierAsaId]);
 
   useEffect(() => {
@@ -337,9 +346,14 @@ export function useBlockchainActions() {
       try {
         const txId = await optInToASA(address, frontierAsaId);
         setLastTxId(txId);
-        setIsOptedIn(true);
-        localStorage.setItem("frontier_opted_in", "true");
-        localStorage.setItem("frontier_opted_in_address", address);
+        // Verify opt-in on-chain before updating UI — no page reload required
+        const updatedInfo = await algodClient.accountInformation(address).do();
+        const confirmed = hasOptedIn(updatedInfo as Record<string, unknown>, frontierAsaId);
+        setIsOptedIn(confirmed);
+        if (confirmed) {
+          localStorage.setItem("frontier_opted_in", "true");
+          localStorage.setItem("frontier_opted_in_address", address);
+        }
         toast({ title: "Opt-In Confirmed", description: `Opted into FRONTIER ASA. TX: ${txId.slice(0, 8)}...` });
         return txId;
       } catch (error: unknown) {

--- a/client/src/lib/algorand.ts
+++ b/client/src/lib/algorand.ts
@@ -288,6 +288,21 @@ export async function isOptedInToASA(address: string, assetId: number): Promise<
   }
 }
 
+/**
+ * Pure helper: checks whether an account is opted into a specific ASA by
+ * inspecting the accountInfo object returned from algodClient.accountInformation().do().
+ * Accepts both the legacy "asset-id" key and the newer "assetIndex" key.
+ */
+export function hasOptedIn(
+  accountInfo: Record<string, unknown>,
+  asaId: number
+): boolean {
+  const assets = (accountInfo.assets as Array<Record<string, unknown>>) ?? [];
+  return assets.some(
+    (a) => Number(a["asset-id"] ?? a["assetIndex"]) === asaId
+  );
+}
+
 let _cachedTreasuryAddress: string | null = null;
 let _cachedAsaId: number | null = null;
 


### PR DESCRIPTION
- Add `hasOptedIn(accountInfo, asaId)` pure helper to algorand.ts that
  reads the algod accountInformation response directly, handling both
  "asset-id" and "assetIndex" key variants
- Replace the `isOptedInToASA` server-API call in useBlockchainActions
  with a direct algodClient.accountInformation() + hasOptedIn check so
  opt-in state is always sourced from the live blockchain (not a stale
  server cache that ignored the asaId parameter)
- After a successful opt-in transaction, re-fetch account info via algod
  and verify with hasOptedIn before updating isFrontierOptedIn state —
  no page reload needed
- Guard handleClaimFrontier in GameLayout.tsx behind isOptedInToFrontier
  so FRONTIER tokens are never claimed before the wallet is opted in

https://claude.ai/code/session_01JYLswfRJeHbg4PoGfoeWmq