### PR TITLE
fix: FRONTIER ASA opt-in UX — one-time opt-in, no reload needed

### DIFF
--- a/client/src/components/game/GameLayout.tsx
+++ b/client/src/components/game/GameLayout.tsx
@@ -237,7 +237,7 @@ export function GameLayout() {
 
   const handleClaimFrontier = async () => {
     if (!player || !gameState) return;
-    if (!isOptedInToFrontier) {
+    if (isOptedInToFrontier === false) {
       toast({ title: "Opt-In Required", description: "Opt into FRONTIER ASA before claiming tokens.", variant: "destructive" });
       return;
     }
@@ -468,7 +468,7 @@ export function GameLayout() {
         <TopBar isConnected={isConnected} mobileMenuContent={mobileMenuContent} />
       </div>
 
-      {isConnected && frontierAsaId && !isOptedInToFrontier && (
+      {isConnected && frontierAsaId && isOptedInToFrontier === false && (
         <div className="absolute top-16 left-1/2 -translate-x-1/2 z-30" data-testid="opt-in-banner">
           <Button
             onClick={signOptInToFrontier}
@@ -482,7 +482,7 @@ export function GameLayout() {
       )}
 
       {player && (
-        <div className={cn("absolute left-1/2 -translate-x-1/2 z-20", isConnected && frontierAsaId && !isOptedInToFrontier ? "top-28" : "top-16")}>
+        <div className={cn("absolute left-1/2 -translate-x-1/2 z-20", isConnected && frontierAsaId && isOptedInToFrontier === false ? "top-28" : "top-16")}>
           <ResourceHUD
             iron={player.iron}
             fuel={player.fuel}

--- a/client/src/hooks/useBlockchainActions.ts
+++ b/client/src/hooks/useBlockchainActions.ts
@@ -16,6 +16,7 @@ import {
   type BatchedAction,
 } from "@/lib/algorand";
 import { useToast } from "@/hooks/use-toast";
+import { queryClient } from "@/lib/queryClient";
 
 type ActionType =
   | "mine"
@@ -37,10 +38,8 @@ export function useBlockchainActions() {
   const [isPending, setIsPending] = useState(false);
   const [lastTxId, setLastTxId] = useState<string | null>(null);
   const [frontierAsaId, setFrontierAsaId] = useState<number | null>(null);
-  const [isOptedIn, setIsOptedIn] = useState(() => {
-    const cached = localStorage.getItem("frontier_opted_in");
-    return cached === "true";
-  });
+  // tri-state: undefined = checking, true = opted in, false = not opted in
+  const [isOptedIn, setIsOptedIn] = useState<boolean | undefined>(undefined);
   const [treasuryAddress, setTreasuryAddress] = useState<string>("");
 
   useEffect(() => {
@@ -50,8 +49,23 @@ export function useBlockchainActions() {
     });
   }, []);
 
+  // Reset to undefined whenever the connected address changes so the previous
+  // wallet's opt-in state is never shown for a different wallet.
+  useEffect(() => {
+    setIsOptedIn(undefined);
+  }, [address]);
+
+  // Once we have both address and ASA id, read the per-wallet+ASA cache first
+  // (so opted-in users never see the banner flash), then verify on-chain in
+  // the background to keep the cache accurate.
   useEffect(() => {
     if (!address || !frontierAsaId) return;
+
+    const cacheKey = `frontier_optin_${address}_${frontierAsaId}`;
+    if (localStorage.getItem(cacheKey) === "true") {
+      setIsOptedIn(true);
+    }
+
     algodClient
       .accountInformation(address)
       .do()
@@ -59,25 +73,15 @@ export function useBlockchainActions() {
         const result = hasOptedIn(accountInfo as Record<string, unknown>, frontierAsaId);
         setIsOptedIn(result);
         if (result) {
-          localStorage.setItem("frontier_opted_in", "true");
-          localStorage.setItem("frontier_opted_in_address", address);
+          localStorage.setItem(cacheKey, "true");
         } else {
-          localStorage.removeItem("frontier_opted_in");
+          localStorage.removeItem(cacheKey);
         }
       })
       .catch(() => {
         // Keep existing cached state if algod is temporarily unreachable
       });
   }, [address, frontierAsaId]);
-
-  useEffect(() => {
-    const cachedAddress = localStorage.getItem("frontier_opted_in_address");
-    if (address && cachedAddress && cachedAddress !== address) {
-      localStorage.removeItem("frontier_opted_in");
-      localStorage.removeItem("frontier_opted_in_address");
-      setIsOptedIn(false);
-    }
-  }, [address]);
 
   useEffect(() => {
     if (!address || !isReady) return;
@@ -337,7 +341,7 @@ export function useBlockchainActions() {
         toast({ title: "Not Ready", description: "FRONTIER token not created yet.", variant: "destructive" });
         return null;
       }
-      if (isOptedIn) {
+      if (isOptedIn === true) {
         toast({ title: "Already Opted In", description: "You're already opted into FRONTIER." });
         return null;
       }
@@ -346,14 +350,13 @@ export function useBlockchainActions() {
       try {
         const txId = await optInToASA(address, frontierAsaId);
         setLastTxId(txId);
-        // Verify opt-in on-chain before updating UI — no page reload required
-        const updatedInfo = await algodClient.accountInformation(address).do();
-        const confirmed = hasOptedIn(updatedInfo as Record<string, unknown>, frontierAsaId);
-        setIsOptedIn(confirmed);
-        if (confirmed) {
-          localStorage.setItem("frontier_opted_in", "true");
-          localStorage.setItem("frontier_opted_in_address", address);
-        }
+        // waitForConfirmation inside optInToASA already confirmed the tx —
+        // optimistically mark as opted-in immediately so the banner disappears.
+        const cacheKey = `frontier_optin_${address}_${frontierAsaId}`;
+        setIsOptedIn(true);
+        localStorage.setItem(cacheKey, "true");
+        // Refetch game state so the HUD and any balance displays update.
+        queryClient.invalidateQueries({ queryKey: ["/api/game/state"] });
         toast({ title: "Opt-In Confirmed", description: `Opted into FRONTIER ASA. TX: ${txId.slice(0, 8)}...` });
         return txId;
       } catch (error: unknown) {

--- a/client/src/lib/algorand.ts
+++ b/client/src/lib/algorand.ts
@@ -230,7 +230,7 @@ export const FRONTIER_ASSETS = {
   iron: { name: "FRONTIER-IRON", unitName: "IRON", decimals: 0 },
   fuel: { name: "FRONTIER-FUEL", unitName: "FUEL", decimals: 0 },
   crystal: { name: "FRONTIER-CRYSTAL", unitName: "CRYSTAL", decimals: 0 },
-  frontier: { name: "FRONTIER", unitName: "FRNTR", decimals: 2 },
+  frontier: { name: "FRONTIER", unitName: "FRNTR", decimals: 6 },
 } as const;
 
 export type FrontierResourceType = keyof typeof FRONTIER_ASSETS;
@@ -271,7 +271,7 @@ export async function optInToASA(
 
 export async function isOptedInToASA(address: string, assetId: number): Promise<boolean> {
   try {
-    const res = await fetch(`/api/blockchain/opt-in-check/${address}`);
+    const res = await fetch(`/api/blockchain/opt-in-check/${address}?assetId=${assetId}`);
     const data = await res.json();
     return data.optedIn === true;
   } catch {
@@ -280,7 +280,7 @@ export async function isOptedInToASA(address: string, assetId: number): Promise<
       const assets = accountInfo.assets || accountInfo["assets"] || [];
       return assets.some((a: any) => {
         const id = a["asset-id"] ?? a.assetIndex ?? a["assetIndex"];
-        return id === assetId;
+        return Number(id) === assetId;
       });
     } catch {
       return false;

--- a/server/algorand.ts
+++ b/server/algorand.ts
@@ -149,15 +149,16 @@ export async function transferFrontierASA(
   return txId;
 }
 
-export async function isAddressOptedInToFrontier(address: string): Promise<boolean> {
-  if (!frontierAsaId) return false;
+export async function isAddressOptedInToFrontier(address: string, assetId?: number): Promise<boolean> {
+  const targetAsaId = assetId ?? frontierAsaId;
+  if (!targetAsaId) return false;
 
   try {
     const accountInfo = await algodClient.accountInformation(address).do();
     const assets = (accountInfo as any).assets || (accountInfo as any)["assets"] || [];
     return assets.some((a: any) => {
       const id = a["asset-id"] ?? a.assetIndex ?? a["assetIndex"];
-      return Number(id) === frontierAsaId;
+      return Number(id) === targetAsaId;
     });
   } catch (err) {
     console.error("Opt-in check failed for", address, err);

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -104,7 +104,8 @@ export async function registerRoutes(
 
   app.get("/api/blockchain/opt-in-check/:address", async (req, res) => {
     try {
-      const optedIn = await isAddressOptedInToFrontier(req.params.address);
+      const queryAsaId = req.query.assetId ? Number(req.query.assetId) : undefined;
+      const optedIn = await isAddressOptedInToFrontier(req.params.address, queryAsaId);
       res.json({ optedIn, asaId: getFrontierAsaId() });
     } catch (error) {
       res.json({ optedIn: false, asaId: getFrontierAsaId() });


### PR DESCRIPTION
- client/lib/algorand.ts: isOptedInToASA now passes ?assetId=<id> to the
  server endpoint so the check is asset-specific (not always the server's
  current frontierAsaId). Fixed FRONTIER_ASSETS.frontier.decimals 2→6 to
  match the on-chain ASA.

- server/algorand.ts: isAddressOptedInToFrontier accepts an optional assetId
  param; when provided it checks that exact ASA instead of the module-level
  frontierAsaId.

- server/routes.ts: /api/blockchain/opt-in-check/:address now reads an
  optional ?assetId query param and forwards it to isAddressOptedInToFrontier.

- client/hooks/useBlockchainActions.ts:
  • isOptedIn is now tri-state (undefined|true|false):
    undefined = still checking (banner stays hidden)
    false     = show banner
    true      = hide banner permanently
  • localStorage key changed to frontier_optin_<address>_<asaId> so each
    wallet+ASA pair has its own cache slot.
  • On connect: cache is read synchronously (no banner flash for opted-in
    users), then algod verifies in background.
  • After signOptInToFrontier: setIsOptedIn(true) and persist cache
    immediately after waitForConfirmation — banner disappears without reload.
  • Added queryClient.invalidateQueries to refresh game state post-opt-in.

- client/components/game/GameLayout.tsx:
  • Banner condition changed from !isOptedInToFrontier to
    isOptedInToFrontier === false — undefined suppresses the banner while
    the on-chain check is in flight.
  • Same fix applied to the ResourceHUD top-offset condition and the
    handleClaimFrontier opt-in guard.

https://claude.ai/code/session_013sREPrhHRmZJxGP3BqdjVm