### PR TITLE
fix(FlatMap): suppress white-square selection artifact on tap/click

### DIFF
--- a/client/src/components/game/FlatMap.tsx
+++ b/client/src/components/game/FlatMap.tsx
@@ -435,8 +435,18 @@ export function FlatMap({
         }
 
         ctx.globalAlpha = plotAlpha;
-        ctx.fillStyle = color;
-        ctx.fillRect(x - size / 2, y - size / 2, size, size);
+        if (isSelected) {
+          // Draw a thin arc ring — no filled square, no white background.
+          // The radius is half of `size` so it scales correctly with zoom.
+          ctx.strokeStyle = "#00e5ff";
+          ctx.lineWidth   = 2;
+          ctx.beginPath();
+          ctx.arc(x, y, size / 2, 0, Math.PI * 2);
+          ctx.stroke();
+        } else {
+          ctx.fillStyle = color;
+          ctx.fillRect(x - size / 2, y - size / 2, size, size);
+        }
         ctx.globalAlpha = 1.0;
 
         ctx.shadowColor = "transparent";
@@ -749,9 +759,25 @@ export function FlatMap({
   }, [selectedParcelId, plotIndex, latLngToScreen, centerOnPlot]);
 
   return (
-    <div ref={containerRef} className={className} style={{ position: "relative", overflow: "hidden" }} data-testid="flat-map">
+    <div
+      ref={containerRef}
+      className={className}
+      style={{
+        position: "relative",
+        overflow: "hidden",
+        // Prevent the wrapper div from showing its own focus ring or tap flash
+        outline: "none",
+        WebkitTapHighlightColor: "transparent",
+        userSelect: "none",
+      }}
+      data-testid="flat-map"
+    >
       <canvas
         ref={canvasRef}
+        // tabIndex={-1} makes the element programmatically focusable but removes it from
+        // the tab order. Combined with outline:none this suppresses the browser focus ring
+        // on click/tap in Chrome, Firefox, and Safari without affecting pointer events.
+        tabIndex={-1}
         onPointerDown={handlePointerDown}
         onPointerMove={handlePointerMove}
         onPointerUp={handlePointerUp}
@@ -765,7 +791,7 @@ export function FlatMap({
           height: "100%",
           touchAction: "none",
           outline: "none",
-          // Suppress mobile browser tap-highlight (the "white circle" flash on iOS Safari)
+          // Suppress mobile browser tap-highlight (the white flash on iOS Safari)
           WebkitTapHighlightColor: "transparent",
           userSelect: "none",
         }}


### PR DESCRIPTION
Three overlapping root causes addressed:

1. canvas tabIndex={-1} — without this attribute, Chrome/Safari grant the
   canvas a visible focus ring on pointer-up even when outline:none is set
   in CSS.  tabIndex={-1} keeps the element focusable programmatically
   (pointer events still fire) but removes it from the tab order and
   fully suppresses the default browser focus ring.

2. Wrapper <div> lacked tap-highlight suppression — added outline:none,
   WebkitTapHighlightColor:transparent, and userSelect:none so iOS Safari
   cannot render its blue/white flash on a parent element.

3. Selected parcel was drawn with ctx.fillRect (a square) — replaced with
   ctx.arc stroke-only ring (#00e5ff, lineWidth 2).  The ring radius is
   size/2 so it scales correctly with zoom.  The outer animated rings
   (already using ctx.arc) are preserved unchanged.

No game logic, minting, wallet, or resource code was modified.

https://claude.ai/code/session_01WuN1e5rsnrGfXAFrcBVAPW