### PR TITLE
Fix port conflicts: Vite on 5000, API on 5001 with concurrently

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "type": "module",
   "license": "MIT",
   "scripts": {
-    "dev": "NODE_ENV=development tsx server/index.ts",
+    "dev": "concurrently -k \"npm run dev:server\" \"npm run dev:client\"",
+    "dev:server": "NODE_ENV=development API_PORT=5001 tsx server/index.ts",
+    "dev:client": "vite --host 0.0.0.0 --port 5000",
     "build": "tsx script/build.ts",
     "start": "NODE_ENV=production node dist/index.cjs",
     "check": "tsc",
@@ -87,6 +89,7 @@
     "zod-validation-error": "^3.4.0"
   },
   "devDependencies": {
+    "concurrently": "^9.0.0",
     "@tailwindcss/typography": "^0.5.15",
     "@tailwindcss/vite": "^4.1.18",
     "@types/connect-pg-simple": "^7.0.3",

--- a/server/index.ts
+++ b/server/index.ts
@@ -81,15 +81,22 @@ app.use((req, res, next) => {
   if (process.env.NODE_ENV === "production") {
     serveStatic(app);
   } else {
-    const { setupVite } = await import("./vite");
-    await setupVite(httpServer, app);
+    // In development, Vite runs separately on port 5000
+    // This server only serves the API on port 5001
+    // If you need Vite middleware for development, use the setupVite function
+    // const { setupVite } = await import("./vite");
+    // await setupVite(httpServer, app);
   }
 
-  // ALWAYS serve the app on the port specified in the environment variable PORT
-  // Other ports are firewalled. Default to 5000 if not specified.
-  // this serves both the API and the client.
-  // It is the only port that is not firewalled.
-  const port = parseInt(process.env.PORT || "5000", 10);
+  // Determine the port:
+  // 1. Use API_PORT if set (for development API server)
+  // 2. Use PORT if set (for explicit override)
+  // 3. Use 5001 in development, 5000 in production
+  const defaultPort = process.env.NODE_ENV === "production" ? 5000 : 5001;
+  const port = parseInt(
+    process.env.API_PORT || process.env.PORT || defaultPort.toString(),
+    10,
+  );
   httpServer.listen(
     {
       port,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -34,7 +34,7 @@ export default defineConfig({
     fs: { strict: true, deny: ["**/.*"] },
     proxy: {
       "/api": {
-        target: "http://0.0.0.0:5000",
+        target: "http://127.0.0.1:5001",
         changeOrigin: true,
       },
     },


### PR DESCRIPTION
- Update vite.config.ts: proxy /api requests to http://127.0.0.1:5001
- Update server/index.ts: Use API_PORT env var, default to 5001 in dev, 5000 in prod
  * Remove Vite middleware setup in development (now runs as separate process)
  * Add support for API_PORT environment variable
- Update package.json: Add npm scripts to run Vite and backend concurrently
  * dev:server: Runs backend on port 5001 with API_PORT=5001
  * dev:client: Runs Vite dev server on port 5000
  * dev: Runs both concurrently with concurrently package
- Add concurrently@^9.0.0 to devDependencies

https://claude.ai/code/session_01BqB9gaBXnNpbVFM2u57toW