### PR TITLE
fix: separate mining from minting, fix batch limits, sync panel UIs

### DIFF
--- a/client/src/components/game/CommandCenterPanel.tsx
+++ b/client/src/components/game/CommandCenterPanel.tsx
@@ -35,14 +35,14 @@ function PlotRow({
   isSelected,
   onSelect,
   onMineParcel,
-  isMining,
+  isMiningThisParcel,
   now,
 }: {
   parcel: LandParcel;
   isSelected: boolean;
   onSelect: () => void;
   onMineParcel: (parcelId: string) => void;
-  isMining: boolean;
+  isMiningThisParcel: boolean;
   now: number;
 }) {
   const elapsed = now - parcel.lastMineTs;
@@ -52,11 +52,6 @@ function PlotRow({
     ((parcel.ironStored + parcel.fuelStored + parcel.crystalStored) /
       parcel.storageCapacity) *
     100;
-
-  const handleMineClick = (e: React.MouseEvent) => {
-    e.stopPropagation();
-    onMineParcel(parcel.id);
-  };
 
   return (
     <div
@@ -127,18 +122,21 @@ function PlotRow({
         )}
       </button>
 
-      {/* Quick mine button */}
+      {/* Mine Resources button — only shown when plot is ready; per-parcel disabled state */}
       {mineReady && (
         <div className="px-3 pb-2 border-t border-border/50">
           <Button
-            onClick={handleMineClick}
-            disabled={isMining}
+            onClick={(e) => {
+              e.stopPropagation();
+              onMineParcel(parcel.id);
+            }}
+            disabled={isMiningThisParcel}
             size="sm"
-            className="w-full h-7 font-display uppercase tracking-wide text-xs"
-            data-testid={`button-quick-mine-${parcel.plotId}`}
+            className="w-full h-7 font-display uppercase tracking-wide text-xs transition-all active:scale-95"
+            data-testid={`button-mine-resources-${parcel.plotId}`}
           >
-            <Pickaxe className="w-3 h-3 mr-1.5" />
-            {isMining ? "Mining..." : "Mine"}
+            <Pickaxe className={cn("w-3 h-3 mr-1.5", isMiningThisParcel && "animate-spin")} />
+            {isMiningThisParcel ? "Extracting..." : "Mine Resources"}
           </Button>
         </div>
       )}
@@ -146,7 +144,7 @@ function PlotRow({
   );
 }
 
-// ─── SelectedParcelActions (inlined from BaseInfoPanel) ──────────────────────
+// ─── SelectedParcelActions ────────────────────────────────────────────────────
 
 function SelectedParcelActions({
   parcel,
@@ -154,7 +152,7 @@ function SelectedParcelActions({
   onMine,
   onUpgrade,
   onAttack,
-  isMining,
+  isMiningThisParcel,
   isUpgrading,
 }: {
   parcel: LandParcel;
@@ -162,7 +160,7 @@ function SelectedParcelActions({
   onMine: () => void;
   onUpgrade: (type: string) => void;
   onAttack: () => void;
-  isMining: boolean;
+  isMiningThisParcel: boolean;
   isUpgrading: boolean;
 }) {
   const [upgradeOpen, setUpgradeOpen] = useState(false);
@@ -248,15 +246,20 @@ function SelectedParcelActions({
           })()}
 
           <div className="space-y-2">
+            {/* Mine For Resources — resource extraction only, NOT token minting */}
             <Button
               onClick={onMine}
-              disabled={!canMine || isMining}
-              className="w-full font-display uppercase tracking-wide"
+              disabled={!canMine || isMiningThisParcel}
+              className="w-full font-display uppercase tracking-wide transition-all active:scale-95"
               size="sm"
               data-testid="button-mine-cc"
             >
-              <Pickaxe className="w-3.5 h-3.5 mr-2" />
-              {isMining ? "Mining..." : "Mine Resources"}
+              <Pickaxe className={cn("w-3.5 h-3.5 mr-2", isMiningThisParcel && "animate-spin")} />
+              {isMiningThisParcel
+                ? "Extracting Resources..."
+                : canMine
+                ? "Mine For Resources"
+                : "Mine Cooldown Active"}
             </Button>
 
             <Collapsible open={upgradeOpen} onOpenChange={setUpgradeOpen}>
@@ -350,6 +353,7 @@ interface CommandCenterPanelProps {
   onCollectAll: () => void;
   onMine: () => void;
   onMineParcel?: (parcelId: string) => void;
+  isMiningParcel?: (parcelId: string) => boolean;
   onUpgrade: (type: string) => void;
   onAttack: () => void;
   isMining: boolean;
@@ -368,6 +372,7 @@ export function CommandCenterPanel({
   onCollectAll,
   onMine,
   onMineParcel,
+  isMiningParcel,
   onUpgrade,
   onAttack,
   isMining,
@@ -402,7 +407,6 @@ export function CommandCenterPanel({
     () => ownedParcels.reduce((s, p) => s + p.frontierPerDay, 0),
     [ownedParcels]
   );
-  // Live total: stored DB amount + time-elapsed earnings since last claim.
   const totalFrontierPending = useMemo(
     () => ownedParcels.reduce((s, p) => s + liveFrontierAccumulated(p, now), 0),
     [ownedParcels, now]
@@ -433,13 +437,13 @@ export function CommandCenterPanel({
         )}
       </div>
 
-      {/* ── FRNTR Accumulation Banner ── */}
+      {/* ── FRNTR Token Mint Banner (ASA tokens only — not related to mining) ── */}
       {player && ownedParcels.length > 0 && (
         <div className="mx-3 mt-3 p-3 rounded-lg border border-primary/40 bg-primary/5 shrink-0">
           <div className="flex items-center gap-1.5 mb-2">
             <TrendingUp className="w-3.5 h-3.5 text-primary" />
             <span className="font-display text-[10px] font-bold uppercase tracking-wider text-primary">
-              FRNTR Generation
+              FRNTR Token Generation
             </span>
           </div>
 
@@ -474,6 +478,7 @@ export function CommandCenterPanel({
             </div>
           </div>
 
+          {/* MINT FRNTR TOKEN — this mints the ASA token, separate from mining */}
           <Button
             onClick={onClaimFrontier}
             disabled={isClaimingFrontier || !hasPending}
@@ -482,20 +487,20 @@ export function CommandCenterPanel({
           >
             <Zap className="w-3.5 h-3.5 mr-1.5" />
             {isClaimingFrontier
-              ? "Minting..."
+              ? "Minting FRNTR Token..."
               : hasPending
-              ? `Mint All — ${totalFrontierPending.toFixed(2)} FRNTR`
+              ? `Mint FRNTR Token — ${totalFrontierPending.toFixed(2)}`
               : "No FRNTR Accumulated Yet"}
           </Button>
           {hasPending && (
             <p className="text-[8px] text-muted-foreground text-center mt-1">
-              Sent in max-batch atomic transactions on-chain
+              Mints FRNTR ASA tokens to your Algorand wallet on-chain
             </p>
           )}
         </div>
       )}
 
-      {/* ── Collect Minerals ── */}
+      {/* ── Collect Minerals — collects extracted resources (iron/fuel/crystal) ── */}
       {player && hasStored && (
         <div className="mx-3 mt-2 shrink-0">
           <Button
@@ -513,13 +518,13 @@ export function CommandCenterPanel({
         </div>
       )}
 
-      {/* ── Lifetime mineral stats ── */}
+      {/* ── Lifetime resource extraction stats ── */}
       {player && (player.totalIronMined > 0 || player.totalFuelMined > 0) && (
         <div className="mx-3 mt-2 p-2 rounded-md bg-muted/20 border border-border shrink-0">
           <div className="flex items-center gap-1 mb-1">
             <FlaskConical className="w-3 h-3 text-muted-foreground" />
             <span className="text-[9px] font-display uppercase tracking-wide text-muted-foreground">
-              Total Extracted
+              Total Resources Extracted
             </span>
           </div>
           <div className="grid grid-cols-3 gap-1 text-center">
@@ -601,14 +606,14 @@ export function CommandCenterPanel({
                 isSelected={selectedParcel?.id === p.id}
                 onSelect={() => onSelectParcel(p.id)}
                 onMineParcel={onMineParcel || (() => {})}
-                isMining={isMining && selectedParcel?.id === p.id}
+                isMiningThisParcel={isMiningParcel ? isMiningParcel(p.id) : false}
                 now={now}
               />
             ))
           )}
         </div>
 
-        {/* ── Selected parcel actions (shown at bottom of scroll area) ── */}
+        {/* ── Selected parcel actions ── */}
         {selectedParcel && player && (
           <div className="mt-3">
             <SelectedParcelActions
@@ -617,7 +622,9 @@ export function CommandCenterPanel({
               onMine={onMine}
               onUpgrade={onUpgrade}
               onAttack={onAttack}
-              isMining={isMining}
+              isMiningThisParcel={
+                isMiningParcel ? isMiningParcel(selectedParcel.id) : isMining
+              }
               isUpgrading={isUpgrading}
             />
           </div>
@@ -656,7 +663,9 @@ export function CommandCenterPanel({
                 onMine={onMine}
                 onUpgrade={onUpgrade}
                 onAttack={onAttack}
-                isMining={isMining}
+                isMiningThisParcel={
+                  isMiningParcel ? isMiningParcel(selectedParcel.id) : isMining
+                }
                 isUpgrading={isUpgrading}
               />
             </div>

--- a/client/src/components/game/GameLayout.tsx
+++ b/client/src/components/game/GameLayout.tsx
@@ -85,6 +85,8 @@ export function GameLayout() {
   const [showGamerTag, setShowGamerTag] = useState(false);
   const [newPlayerId, setNewPlayerId] = useState<string | null>(null);
   const [now, setNow] = useState(() => Date.now());
+  // Per-parcel mining state — prevents double-clicks and rapid-fire clicking
+  const [miningParcelIds, setMiningParcelIds] = useState<Set<string>>(new Set());
 
   // Tick every second for live FRNTR accumulation display in ResourceHUD.
   useEffect(() => {
@@ -145,14 +147,14 @@ export function GameLayout() {
 
   const handleMine = async () => {
     if (!player || !selectedParcelId || !selectedParcel) return;
-    // Log to chain (batched, fire-and-forget)
-    queueMineAction(selectedParcel.plotId);
+    if (miningParcelIds.has(selectedParcelId)) return;
+    setMiningParcelIds((prev) => new Set([...prev, selectedParcelId]));
     mineMutation.mutate(
       { playerId: player.id, parcelId: selectedParcelId },
       {
         onSuccess: (data: any) => {
           const yields = data?.yield as { iron: number; fuel: number; crystal: number } | undefined;
-          // Log to chain (batched, fire-and-forget) with actual mineral yields
+          // Log the mine action to chain once (after success) with actual mineral yields
           queueMineAction(selectedParcel.plotId, yields);
           const desc = yields
             ? `+${yields.iron} Iron, +${yields.fuel} Fuel, +${yields.crystal} Crystal`
@@ -160,22 +162,29 @@ export function GameLayout() {
           toast({ title: "Mining Complete", description: desc });
         },
         onError: (error) => toast({ title: "Mining Failed", description: error.message, variant: "destructive" }),
+        onSettled: () => {
+          setMiningParcelIds((prev) => {
+            const next = new Set(prev);
+            next.delete(selectedParcelId);
+            return next;
+          });
+        },
       }
     );
   };
 
   const handleMineParcel = async (parcelId: string) => {
     if (!player) return;
+    if (miningParcelIds.has(parcelId)) return;
     const parcel = gameState?.parcels.find(p => p.id === parcelId);
     if (!parcel) return;
-    // Log to chain (batched, fire-and-forget)
-    queueMineAction(parcel.plotId);
+    setMiningParcelIds((prev) => new Set([...prev, parcelId]));
     mineMutation.mutate(
       { playerId: player.id, parcelId },
       {
         onSuccess: (data: any) => {
           const yields = data?.yield as { iron: number; fuel: number; crystal: number } | undefined;
-          // Log to chain (batched, fire-and-forget) with actual mineral yields
+          // Log the mine action to chain once (after success) with actual mineral yields
           queueMineAction(parcel.plotId, yields);
           const desc = yields
             ? `+${yields.iron} Iron, +${yields.fuel} Fuel, +${yields.crystal} Crystal`
@@ -183,6 +192,13 @@ export function GameLayout() {
           toast({ title: "Mining Complete", description: desc });
         },
         onError: (error) => toast({ title: "Mining Failed", description: error.message, variant: "destructive" }),
+        onSettled: () => {
+          setMiningParcelIds((prev) => {
+            const next = new Set(prev);
+            next.delete(parcelId);
+            return next;
+          });
+        },
       }
     );
   };
@@ -458,6 +474,8 @@ export function GameLayout() {
     );
   }
 
+  const isMiningParcel = (parcelId: string) => miningParcelIds.has(parcelId);
+
   const commandCenterProps = {
     player,
     parcels: gameState?.parcels ?? [],
@@ -469,6 +487,7 @@ export function GameLayout() {
     onCollectAll: handleCollectAll,
     onMine: handleMine,
     onMineParcel: handleMineParcel,
+    isMiningParcel,
     onUpgrade: handleUpgrade,
     onAttack: handleAttackClick,
     isMining: mineMutation.isPending,
@@ -599,6 +618,8 @@ export function GameLayout() {
               onCollectAll={handleCollectAll}
               onClaimFrontier={handleClaimFrontier}
               onSelectParcel={handleParcelSelectFromInventory}
+              onMineParcel={handleMineParcel}
+              isMiningParcel={isMiningParcel}
               isCollecting={collectMutation.isPending}
               isClaimingFrontier={claimFrontierMutation.isPending}
             />

--- a/client/src/components/game/InventoryPanel.tsx
+++ b/client/src/components/game/InventoryPanel.tsx
@@ -1,12 +1,22 @@
-import { useState, useEffect } from "react";
-import { Package, Pickaxe, Fuel, Gem, MapPin, Shield, ArrowDownToLine, Zap, FlaskConical } from "lucide-react";
+import { useState, useEffect, useMemo } from "react";
+import {
+  Package, Pickaxe, Fuel, Gem, MapPin, Shield,
+  ArrowDownToLine, Zap, FlaskConical, Search, Clock, CheckCircle,
+} from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Progress } from "@/components/ui/progress";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
 import type { Player, LandParcel } from "@shared/schema";
-import { biomeColors } from "@shared/schema";
+import { biomeColors, MINE_COOLDOWN_MS } from "@shared/schema";
+
+function formatCooldown(ms: number): string {
+  const m = Math.floor(ms / 60000);
+  const s = Math.floor((ms % 60000) / 1000);
+  return `${m}:${s.toString().padStart(2, "0")}`;
+}
 
 interface InventoryPanelProps {
   player: Player | null;
@@ -14,61 +24,117 @@ interface InventoryPanelProps {
   onCollectAll: () => void;
   onClaimFrontier: () => void;
   onSelectParcel: (id: string) => void;
+  onMineParcel?: (parcelId: string) => void;
+  isMiningParcel?: (parcelId: string) => boolean;
   isCollecting: boolean;
   isClaimingFrontier: boolean;
   className?: string;
 }
 
-function LandCard({ parcel, onSelect, now }: { parcel: LandParcel; onSelect: () => void; now: number }) {
-  const liveAccum = parcel.frontierAccumulated + Math.max(0, (now - parcel.lastFrontierClaimTs) / (1000 * 60 * 60 * 24)) * parcel.frontierPerDay;
+function LandCard({
+  parcel,
+  onSelect,
+  onMineParcel,
+  isMiningThisParcel,
+  now,
+}: {
+  parcel: LandParcel;
+  onSelect: () => void;
+  onMineParcel?: (parcelId: string) => void;
+  isMiningThisParcel: boolean;
+  now: number;
+}) {
+  const liveAccum =
+    parcel.frontierAccumulated +
+    Math.max(0, (now - parcel.lastFrontierClaimTs) / (1000 * 60 * 60 * 24)) *
+      parcel.frontierPerDay;
   const totalStored = parcel.ironStored + parcel.fuelStored + parcel.crystalStored;
   const storagePercent = (totalStored / parcel.storageCapacity) * 100;
 
+  const elapsed = now - parcel.lastMineTs;
+  const remaining = Math.max(0, MINE_COOLDOWN_MS - elapsed);
+  const mineReady = remaining === 0;
+
   return (
-    <button
-      onClick={onSelect}
-      className="w-full p-3 border border-border rounded-md text-left hover:bg-muted/40 transition-colors active:bg-muted/60"
+    <div
+      className="w-full border border-border rounded-md overflow-hidden bg-muted/10 hover:bg-muted/20 transition-colors"
       data-testid={`land-card-${parcel.plotId}`}
     >
-      <div className="flex items-center gap-2 mb-2">
-        <div
-          className="w-6 h-6 rounded-md flex items-center justify-center shrink-0"
-          style={{ backgroundColor: biomeColors[parcel.biome] + "30" }}
-        >
-          <MapPin className="w-3 h-3" style={{ color: biomeColors[parcel.biome] }} />
+      {/* Clickable card body — navigates to plot on map */}
+      <button
+        onClick={onSelect}
+        className="w-full p-3 text-left"
+      >
+        <div className="flex items-center gap-2 mb-2">
+          <div
+            className="w-6 h-6 rounded-md flex items-center justify-center shrink-0"
+            style={{ backgroundColor: biomeColors[parcel.biome] + "30" }}
+          >
+            <MapPin className="w-3 h-3" style={{ color: biomeColors[parcel.biome] }} />
+          </div>
+          <span className="font-display text-xs font-bold uppercase tracking-wide flex-1">
+            Plot #{parcel.plotId}
+          </span>
+          <Badge variant="outline" className="text-[9px] capitalize shrink-0">
+            {parcel.biome}
+          </Badge>
+          {/* Green checkmark when ready to mine */}
+          {mineReady ? (
+            <CheckCircle className="w-3.5 h-3.5 text-green-500 shrink-0" />
+          ) : (
+            <div className="flex items-center gap-0.5 text-[9px] text-muted-foreground font-mono shrink-0">
+              <Clock className="w-3 h-3" />
+              {formatCooldown(remaining)}
+            </div>
+          )}
         </div>
-        <span className="font-display text-xs font-bold uppercase tracking-wide">
-          Plot #{parcel.plotId}
-        </span>
-        <Badge variant="outline" className="text-[9px] capitalize ml-auto">{parcel.biome}</Badge>
-      </div>
 
-      <div className="flex items-center gap-3 mb-1.5 text-[10px]">
-        <span className="flex items-center gap-1">
-          <Shield className="w-3 h-3 text-primary" /> {parcel.defenseLevel}
-        </span>
-        <span className="flex items-center gap-1 text-iron">
-          <Pickaxe className="w-3 h-3" /> {parcel.ironStored}
-        </span>
-        <span className="flex items-center gap-1 text-fuel">
-          <Fuel className="w-3 h-3" /> {parcel.fuelStored}
-        </span>
-        <span className="flex items-center gap-1 text-crystal">
-          <Gem className="w-3 h-3" /> {parcel.crystalStored}
-        </span>
-        <span className="flex items-center gap-1 text-primary ml-auto">
-          <Zap className="w-3 h-3" /> {parcel.frontierPerDay.toFixed(1)}/day
-        </span>
-      </div>
+        <div className="flex items-center gap-3 mb-1.5 text-[10px]">
+          <span className="flex items-center gap-1">
+            <Shield className="w-3 h-3 text-primary" /> {parcel.defenseLevel}
+          </span>
+          <span className="flex items-center gap-1 text-iron">
+            <Pickaxe className="w-3 h-3" /> {parcel.ironStored}
+          </span>
+          <span className="flex items-center gap-1 text-fuel">
+            <Fuel className="w-3 h-3" /> {parcel.fuelStored}
+          </span>
+          <span className="flex items-center gap-1 text-crystal">
+            <Gem className="w-3 h-3" /> {parcel.crystalStored}
+          </span>
+          <span className="flex items-center gap-1 text-primary ml-auto">
+            <Zap className="w-3 h-3" /> {parcel.frontierPerDay.toFixed(1)}/day
+          </span>
+        </div>
 
-      <Progress value={storagePercent} className="h-1" />
-      <div className="flex items-center justify-between mt-1 text-[9px] text-muted-foreground">
-        <span>{totalStored}/{parcel.storageCapacity} stored</span>
-        {liveAccum > 0.001 && (
-          <span className="text-yellow-400">{liveAccum.toFixed(4)} FRNTR pending</span>
-        )}
-      </div>
-    </button>
+        <Progress value={storagePercent} className="h-1" />
+        <div className="flex items-center justify-between mt-1 text-[9px] text-muted-foreground">
+          <span>{totalStored}/{parcel.storageCapacity} stored</span>
+          {liveAccum > 0.001 && (
+            <span className="text-yellow-400">{liveAccum.toFixed(4)} FRNTR pending</span>
+          )}
+        </div>
+      </button>
+
+      {/* Mine Resources button — only shown when plot is ready */}
+      {mineReady && onMineParcel && (
+        <div className="px-3 pb-2 border-t border-border/50">
+          <Button
+            onClick={(e) => {
+              e.stopPropagation();
+              onMineParcel(parcel.id);
+            }}
+            disabled={isMiningThisParcel}
+            size="sm"
+            className="w-full h-7 font-display uppercase tracking-wide text-xs transition-all active:scale-95"
+            data-testid={`button-inv-mine-${parcel.plotId}`}
+          >
+            <Pickaxe className={cn("w-3 h-3 mr-1.5", isMiningThisParcel && "animate-spin")} />
+            {isMiningThisParcel ? "Extracting..." : "Mine Resources"}
+          </Button>
+        </div>
+      )}
+    </div>
   );
 }
 
@@ -78,6 +144,8 @@ export function InventoryPanel({
   onCollectAll,
   onClaimFrontier,
   onSelectParcel,
+  onMineParcel,
+  isMiningParcel,
   isCollecting,
   isClaimingFrontier,
   className,
@@ -92,16 +160,29 @@ export function InventoryPanel({
   }
 
   const [now, setNow] = useState(() => Date.now());
+  const [searchQuery, setSearchQuery] = useState("");
+
   useEffect(() => {
     const id = setInterval(() => setNow(Date.now()), 1000);
     return () => clearInterval(id);
   }, []);
 
-  const ownedParcels = parcels.filter(p => p.ownerId === player.id);
+  const ownedParcels = useMemo(
+    () => parcels.filter((p) => p.ownerId === player.id),
+    [parcels, player.id]
+  );
+
+  const filteredParcels = useMemo(() => {
+    const q = searchQuery.trim();
+    if (!q) return ownedParcels;
+    return ownedParcels.filter((p) => String(p.plotId).includes(q));
+  }, [ownedParcels, searchQuery]);
+
   const totalStoredIron = ownedParcels.reduce((s, p) => s + p.ironStored, 0);
   const totalStoredFuel = ownedParcels.reduce((s, p) => s + p.fuelStored, 0);
   const totalStoredCrystal = ownedParcels.reduce((s, p) => s + p.crystalStored, 0);
   const hasStored = totalStoredIron > 0 || totalStoredFuel > 0 || totalStoredCrystal > 0;
+
   const totalFrontierPending = ownedParcels.reduce((s, p) => {
     const days = Math.max(0, (now - p.lastFrontierClaimTs) / (1000 * 60 * 60 * 24));
     return s + p.frontierAccumulated + days * p.frontierPerDay;
@@ -110,6 +191,7 @@ export function InventoryPanel({
 
   return (
     <div className={cn("flex flex-col h-full", className)} data-testid="inventory-panel">
+      {/* ── Header ── */}
       <div className="p-4 border-b border-border">
         <div className="flex items-center gap-2 mb-3">
           <Package className="w-5 h-5 text-primary" />
@@ -119,7 +201,7 @@ export function InventoryPanel({
           </span>
         </div>
 
-        {/* Wallet balances */}
+        {/* Wallet resource balances */}
         <div className="grid grid-cols-4 gap-2 mb-3">
           <div className="p-2.5 rounded-md bg-muted/50 text-center">
             <Pickaxe className="w-4 h-4 mx-auto mb-1 text-iron" />
@@ -143,11 +225,11 @@ export function InventoryPanel({
           </div>
         </div>
 
-        {/* Lifetime mineral totals */}
+        {/* Lifetime resource extraction totals */}
         <div className="rounded-md bg-muted/30 p-2.5 mb-3">
           <div className="flex items-center gap-1 mb-1.5">
             <FlaskConical className="w-3 h-3 text-muted-foreground" />
-            <span className="text-[10px] font-display uppercase tracking-wide text-muted-foreground">Total Extracted (Lifetime)</span>
+            <span className="text-[10px] font-display uppercase tracking-wide text-muted-foreground">Total Resources Extracted</span>
           </div>
           <div className="grid grid-cols-3 gap-2 text-center">
             <div>
@@ -178,6 +260,7 @@ export function InventoryPanel({
               {isCollecting ? "Collecting..." : `Collect +${totalStoredIron}Fe +${totalStoredFuel}Fu +${totalStoredCrystal}Cr`}
             </Button>
           )}
+          {/* MINT button — mints FRNTR ASA token, separate from mining */}
           {hasPending && (
             <Button
               variant="secondary"
@@ -199,12 +282,30 @@ export function InventoryPanel({
         )}
       </div>
 
-      <div className="px-4 pt-3 pb-1.5">
-        <span className="text-xs font-display uppercase tracking-wide text-muted-foreground">
-          Your Territories ({ownedParcels.length})
-        </span>
+      {/* ── Territories header + search ── */}
+      <div className="px-4 pt-3 pb-2 shrink-0">
+        <div className="flex items-center gap-2 mb-2">
+          <span className="text-xs font-display uppercase tracking-wide text-muted-foreground flex-1">
+            Your Territories ({ownedParcels.length})
+          </span>
+        </div>
+
+        {/* Search bar */}
+        {ownedParcels.length > 0 && (
+          <div className="relative">
+            <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-muted-foreground" />
+            <Input
+              placeholder="Search by plot ID…"
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              className="pl-8 h-8 text-xs font-mono"
+              data-testid="input-inventory-plot-search"
+            />
+          </div>
+        )}
       </div>
 
+      {/* ── Territory list ── */}
       <ScrollArea className="flex-1 px-4 pb-4">
         <div className="space-y-2">
           {ownedParcels.length === 0 ? (
@@ -213,9 +314,21 @@ export function InventoryPanel({
               <p className="text-sm">No territories yet</p>
               <p className="text-xs mt-1">Purchase land from the map</p>
             </div>
+          ) : filteredParcels.length === 0 && searchQuery ? (
+            <div className="text-center py-6 text-muted-foreground">
+              <Search className="w-6 h-6 mx-auto mb-2 opacity-30" />
+              <p className="text-xs">No plots match "{searchQuery}"</p>
+            </div>
           ) : (
-            ownedParcels.map((p) => (
-              <LandCard key={p.id} parcel={p} onSelect={() => onSelectParcel(p.id)} now={now} />
+            filteredParcels.map((p) => (
+              <LandCard
+                key={p.id}
+                parcel={p}
+                onSelect={() => onSelectParcel(p.id)}
+                onMineParcel={onMineParcel}
+                isMiningThisParcel={isMiningParcel ? isMiningParcel(p.id) : false}
+                now={now}
+              />
             ))
           )}
         </div>

--- a/client/src/hooks/useBlockchainActions.ts
+++ b/client/src/hooks/useBlockchainActions.ts
@@ -89,37 +89,33 @@ export function useBlockchainActions() {
     const statusHandler: BatchStatusCallback = (event, detail) => {
       switch (event) {
         case "bundling":
-          toast({
-            title: "Bundling Operations",
-            description: `Bundling ${detail.count}/16 operations...`,
-            duration: 2000,
-          });
+          // bundling event is informational only — no toast needed
           break;
         case "submitting":
           toast({
-            title: "Submitting Batch",
-            description: `Submitting batch (${detail.count} ops)`,
+            title: "Logging to Chain",
+            description: `Recording ${detail.count} game action${detail.count !== 1 ? "s" : ""} to Algorand...`,
             duration: 3000,
           });
           break;
         case "confirmed":
           toast({
-            title: "Satellite Relay Confirmed",
-            description: `${detail.count} action${detail.count !== 1 ? "s" : ""} uplinked to Algorand${detail.txIds?.[0] ? `. TX: ${detail.txIds[0].slice(0, 8)}...` : ""}`,
+            title: "Actions Logged",
+            description: `${detail.count} game action${detail.count !== 1 ? "s" : ""} recorded on Algorand${detail.txIds?.[0] ? `. TX: ${detail.txIds[0].slice(0, 8)}...` : ""}`,
           });
           break;
         case "error": {
           const msg = detail.message || "Unknown error";
           if (!msg.includes("cancelled") && !msg.includes("rejected")) {
             toast({
-              title: "Batch Failed",
+              title: "Chain Log Failed",
               description: msg.slice(0, 100),
               variant: "destructive",
             });
           } else {
             toast({
-              title: "Batch Cancelled",
-              description: "You cancelled the transaction in your wallet.",
+              title: "Cancelled",
+              description: "You cancelled the wallet transaction.",
             });
           }
           break;

--- a/client/src/lib/algorand.ts
+++ b/client/src/lib/algorand.ts
@@ -422,7 +422,7 @@ export function getCachedAsaId(): number | null {
 // an atomic group. A hard MAX_WAIT_MS cap prevents indefinite queueing.
 // ---------------------------------------------------------------------------
 
-export const MAX_GROUP_SIZE = 16;
+export const MAX_GROUP_SIZE = 8;
 export const BATCH_WINDOW_MS = 800;
 export const MAX_WAIT_MS = 2000;
 
@@ -440,9 +440,9 @@ type BatchSignCallback = (actions: BatchedAction[]) => Promise<string | null>;
 // Increase MAX_ACTIONS to allow more actions to accumulate before flushing.
 // The "Satellite Relay" framing makes this feel like a game mechanic, not lag.
 const MAX_BATCH_NOTE_BYTES   = 1000;  // stay under Algorand's 1024-byte limit
-const MAX_ACTIONS_PER_FLUSH  = 16;    // Algorand group-tx limit (also our soft cap)
-const FLUSH_INTERVAL_MS      = 15_000; // Satellite relay window: 15 seconds
-const FLUSH_MAX_WAIT_MS      = 45_000; // Never hold longer than 45 seconds
+const MAX_ACTIONS_PER_FLUSH  = 8;     // Hard cap: flush before Algorand's 16-txn group limit
+const FLUSH_INTERVAL_MS      = 5_000; // Relay window: 5 seconds (was 15s — prevents overrun)
+const FLUSH_MAX_WAIT_MS      = 15_000; // Never hold longer than 15 seconds (was 45s)
 interface TxnQueueEntry {
   action: BatchedAction;
   enqueuedAt: number;


### PR DESCRIPTION
- Mining (iron/fuel/crystal) and minting (FRNTR ASA token) are now
  clearly distinct operations with separate buttons and labels.
  Clicking "Mine For Resources" never triggers a token mint.

- Remove duplicate queueMineAction calls: was called twice per mine
  (once before and once after the server call), meaning 8 mines would
  produce 16 blockchain log entries and hit Algorand's group-tx limit.
  Now called once per mine, only after server success, with actual yields.

- Reduce batch flush threshold: MAX_ACTIONS_PER_FLUSH 16→8,
  FLUSH_INTERVAL_MS 15s→5s, FLUSH_MAX_WAIT_MS 45s→15s to prevent
  queue overrun and wallet-popup errors.

- Add per-parcel mining state (miningParcelIds Set) in GameLayout so
  each plot shows an independent "Extracting..." spinner while mining,
  prevents double-clicks, and the button animates with active:scale-95.

- CommandCenterPanel: rename buttons to "Mine For Resources" / "Mine
  Resources"; Mint button clearly labeled "Mint FRNTR Token"; toast
  messages updated to say "Logging to Chain" not "Bundling operations".

- InventoryPanel (mobile): now matches CommandCenterPanel feature-for-
  feature — search bar for territories, green checkmark (CheckCircle)
  on plots that are ready to mine, "Mine Resources" button on each tile,
  per-parcel loading state. Both panels show identical info.

https://claude.ai/code/session_014UehmRUPaNWYkz4RKsCzG8