### PR TITLE
feat: globe link on battles, random locate buttons, 16-txn batch limit

### DIFF
--- a/client/src/components/game/BattlesPanel.tsx
+++ b/client/src/components/game/BattlesPanel.tsx
@@ -1,4 +1,4 @@
-import { Swords, Clock, User, Bot, ChevronRight, AlertTriangle, CheckCircle2, Eye } from "lucide-react";
+import { Swords, Clock, User, Bot, ChevronRight, AlertTriangle, CheckCircle2, Eye, Globe } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
@@ -11,6 +11,7 @@ interface BattlesPanelProps {
   events: GameEvent[];
   players: Player[];
   onWatchBattle?: (battleId: string) => void;
+  onViewOnGlobe?: (parcelId: string) => void;
   className?: string;
 }
 
@@ -18,10 +19,12 @@ function BattleCard({
   battle,
   players,
   onWatch,
+  onViewOnGlobe,
 }: {
   battle: Battle;
   players: Player[];
   onWatch?: (id: string) => void;
+  onViewOnGlobe?: (parcelId: string) => void;
 }) {
   const attacker = players.find((p) => p.id === battle.attackerId);
   const defender = players.find((p) => p.id === battle.defenderId);
@@ -102,17 +105,30 @@ function BattleCard({
         </span>
       </div>
 
-      {onWatch && (
-        <Button
-          variant="outline"
-          size="sm"
-          className="w-full h-7 text-[10px] font-display uppercase tracking-wide gap-1.5"
-          onClick={() => onWatch(battle.id)}
-        >
-          <Eye className="w-3 h-3" />
-          Watch Battle
-        </Button>
-      )}
+      <div className="flex gap-1.5">
+        {onViewOnGlobe && (
+          <Button
+            variant="outline"
+            size="sm"
+            className="flex-1 h-7 text-[10px] font-display uppercase tracking-wide gap-1.5 border-cyan-500/40 text-cyan-400 hover:bg-cyan-500/10"
+            onClick={() => onViewOnGlobe(battle.targetParcelId)}
+          >
+            <Globe className="w-3 h-3" />
+            View Plot
+          </Button>
+        )}
+        {onWatch && (
+          <Button
+            variant="outline"
+            size="sm"
+            className="flex-1 h-7 text-[10px] font-display uppercase tracking-wide gap-1.5"
+            onClick={() => onWatch(battle.id)}
+          >
+            <Eye className="w-3 h-3" />
+            Watch Battle
+          </Button>
+        )}
+      </div>
     </div>
   );
 }
@@ -158,7 +174,7 @@ function EventItem({ event }: { event: GameEvent }) {
   );
 }
 
-export function BattlesPanel({ battles, events, players, onWatchBattle, className }: BattlesPanelProps) {
+export function BattlesPanel({ battles, events, players, onWatchBattle, onViewOnGlobe, className }: BattlesPanelProps) {
   const activeBattles = battles.filter((b) => b.status === "pending");
   const recentBattles = battles.filter((b) => b.status === "resolved").slice(0, 10);
   const battleEvents = events
@@ -185,7 +201,7 @@ export function BattlesPanel({ battles, events, players, onWatchBattle, classNam
                 <AlertTriangle className="w-3 h-3" /> Active Battles
               </h3>
               {activeBattles.map((b) => (
-                <BattleCard key={b.id} battle={b} players={players} onWatch={onWatchBattle} />
+                <BattleCard key={b.id} battle={b} players={players} onWatch={onWatchBattle} onViewOnGlobe={onViewOnGlobe} />
               ))}
             </div>
           )}
@@ -196,7 +212,7 @@ export function BattlesPanel({ battles, events, players, onWatchBattle, classNam
                 Recent Battles
               </h3>
               {recentBattles.map((b) => (
-                <BattleCard key={b.id} battle={b} players={players} onWatch={onWatchBattle} />
+                <BattleCard key={b.id} battle={b} players={players} onWatch={onWatchBattle} onViewOnGlobe={onViewOnGlobe} />
               ))}
             </div>
           )}

--- a/client/src/components/game/FlatMap.tsx
+++ b/client/src/components/game/FlatMap.tsx
@@ -729,11 +729,8 @@ export function FlatMap({
 
   const handleLocate = useCallback(() => {
     if (onLocateTerritory) onLocateTerritory();
-    if (currentPlayerId) {
-      const owned = parcels.find((p) => p.ownerId === currentPlayerId);
-      if (owned) centerOnPlot(owned);
-    }
-  }, [onLocateTerritory, currentPlayerId, parcels, centerOnPlot]);
+    // Centering is handled by the selectedParcelId effect after GameLayout sets the new random plot
+  }, [onLocateTerritory]);
 
   const handleFindEnemy = useCallback(() => {
     if (onFindEnemyTarget) onFindEnemyTarget();
@@ -743,20 +740,14 @@ export function FlatMap({
     setCamera({ centerLat: 0, centerLng: 0, zoom: 1 });
   }, []);
 
-  // Auto-rotate globe to bring a newly selected plot into view if it is on the back hemisphere.
+  // Auto-rotate globe to center on a newly selected plot.
+  // Always centers so that locate/enemy/battle-link actions always bring the plot into view.
   useEffect(() => {
     if (selectedParcelId) {
       const plot = plotIndex.get(selectedParcelId);
-      if (plot) {
-        const canvas = canvasRef.current;
-        if (canvas) {
-          const rect      = canvas.getBoundingClientRect();
-          const screenPos = latLngToScreen(plot.lat, plot.lng, rect.width, rect.height);
-          if (!screenPos) centerOnPlot(plot);
-        }
-      }
+      if (plot) centerOnPlot(plot);
     }
-  }, [selectedParcelId, plotIndex, latLngToScreen, centerOnPlot]);
+  }, [selectedParcelId, plotIndex, centerOnPlot]);
 
   return (
     <div

--- a/client/src/components/game/GameLayout.tsx
+++ b/client/src/components/game/GameLayout.tsx
@@ -87,6 +87,8 @@ export function GameLayout() {
   const [now, setNow] = useState(() => Date.now());
   // Per-parcel mining state — prevents double-clicks and rapid-fire clicking
   const [miningParcelIds, setMiningParcelIds] = useState<Set<string>>(new Set());
+  const lastLocatedOwnedId = useRef<string | null>(null);
+  const lastLocatedEnemyId = useRef<string | null>(null);
 
   // Tick every second for live FRNTR accumulation display in ResourceHUD.
   useEffect(() => {
@@ -385,7 +387,12 @@ export function GameLayout() {
     if (!player || !gameState) return;
     const ownedPlots = gameState.parcels.filter(p => p.ownerId === player.id);
     if (ownedPlots.length > 0) {
-      setSelectedParcelId(ownedPlots[0].id);
+      // Pick a random plot that differs from the last one shown (if possible)
+      let candidates = ownedPlots.filter(p => p.id !== lastLocatedOwnedId.current);
+      if (candidates.length === 0) candidates = ownedPlots;
+      const pick = candidates[Math.floor(Math.random() * candidates.length)];
+      lastLocatedOwnedId.current = pick.id;
+      setSelectedParcelId(pick.id);
       setActiveTab("map");
     }
   };
@@ -394,13 +401,22 @@ export function GameLayout() {
     if (!gameState) return;
     const enemyPlots = gameState.parcels.filter(p => p.ownerId && p.ownerId !== player?.id);
     if (enemyPlots.length > 0) {
-      const randomEnemy = enemyPlots[Math.floor(Math.random() * enemyPlots.length)];
+      // Pick a random enemy plot that differs from the last one shown (if possible)
+      let candidates = enemyPlots.filter(p => p.id !== lastLocatedEnemyId.current);
+      if (candidates.length === 0) candidates = enemyPlots;
+      const randomEnemy = candidates[Math.floor(Math.random() * candidates.length)];
+      lastLocatedEnemyId.current = randomEnemy.id;
       setSelectedParcelId(randomEnemy.id);
       setActiveTab("map");
       toast({ title: "Enemy Located", description: `Plot #${randomEnemy.plotId} owned by ${randomEnemy.ownerType === "ai" ? "AI Faction" : "Player"} — tap to attack!` });
     } else {
       toast({ title: "No Enemies Found", description: "No enemy territories detected yet." });
     }
+  };
+
+  const handleViewOnGlobe = (parcelId: string) => {
+    setSelectedParcelId(parcelId);
+    setActiveTab("map");
   };
 
   const playerHasOwnedPlots = player && gameState ? gameState.parcels.some(p => p.ownerId === player.id) : false;
@@ -604,6 +620,7 @@ export function GameLayout() {
             events={gameState.events}
             players={gameState.players}
             onWatchBattle={setWatchingBattleId}
+            onViewOnGlobe={handleViewOnGlobe}
             className="h-full border-0 rounded-none"
           />
         ) : null}
@@ -630,6 +647,7 @@ export function GameLayout() {
               events={gameState.events}
               players={gameState.players}
               onWatchBattle={setWatchingBattleId}
+              onViewOnGlobe={handleViewOnGlobe}
             />
           )}
           {activeTab === "commander" && gameState && (

--- a/client/src/components/game/WarRoomPanel.tsx
+++ b/client/src/components/game/WarRoomPanel.tsx
@@ -1,4 +1,4 @@
-import { Swords, Clock, User, Bot, ChevronRight, AlertTriangle, CheckCircle2, XCircle, TrendingDown, ShieldOff, Eye } from "lucide-react";
+import { Swords, Clock, User, Bot, ChevronRight, AlertTriangle, CheckCircle2, XCircle, TrendingDown, ShieldOff, Eye, Globe } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
@@ -13,10 +13,11 @@ interface WarRoomPanelProps {
   events: GameEvent[];
   players: Player[];
   onWatchBattle?: (battleId: string) => void;
+  onViewOnGlobe?: (parcelId: string) => void;
   className?: string;
 }
 
-function BattleCard({ battle, players, onWatch }: { battle: Battle; players: Player[]; onWatch?: (id: string) => void }) {
+function BattleCard({ battle, players, onWatch, onViewOnGlobe }: { battle: Battle; players: Player[]; onWatch?: (id: string) => void; onViewOnGlobe?: (parcelId: string) => void }) {
   const attacker = players.find((p) => p.id === battle.attackerId);
   const defender = players.find((p) => p.id === battle.defenderId);
   const now = Date.now();
@@ -85,17 +86,30 @@ function BattleCard({ battle, players, onWatch }: { battle: Battle; players: Pla
         </span>
       </div>
 
-      {onWatch && (
-        <Button
-          variant="outline"
-          size="sm"
-          className="w-full h-7 text-[10px] font-display uppercase tracking-wide gap-1.5"
-          onClick={() => onWatch(battle.id)}
-        >
-          <Eye className="w-3 h-3" />
-          Watch Battle
-        </Button>
-      )}
+      <div className="flex gap-1.5">
+        {onViewOnGlobe && (
+          <Button
+            variant="outline"
+            size="sm"
+            className="flex-1 h-7 text-[10px] font-display uppercase tracking-wide gap-1.5 border-cyan-500/40 text-cyan-400 hover:bg-cyan-500/10"
+            onClick={() => onViewOnGlobe(battle.targetParcelId)}
+          >
+            <Globe className="w-3 h-3" />
+            View Plot
+          </Button>
+        )}
+        {onWatch && (
+          <Button
+            variant="outline"
+            size="sm"
+            className="flex-1 h-7 text-[10px] font-display uppercase tracking-wide gap-1.5"
+            onClick={() => onWatch(battle.id)}
+          >
+            <Eye className="w-3 h-3" />
+            Watch Battle
+          </Button>
+        )}
+      </div>
     </div>
   );
 }
@@ -200,7 +214,7 @@ function AIActivityFeed({ players, events }: { players: Player[]; events: GameEv
   );
 }
 
-export function WarRoomPanel({ battles, events, players, onWatchBattle, className }: WarRoomPanelProps) {
+export function WarRoomPanel({ battles, events, players, onWatchBattle, onViewOnGlobe, className }: WarRoomPanelProps) {
   const activeBattles = battles.filter((b) => b.status === "pending");
   const recentBattles = battles.filter((b) => b.status === "resolved").slice(0, 5);
   const recentEvents = events.slice(0, 15);
@@ -255,13 +269,13 @@ export function WarRoomPanel({ battles, events, players, onWatchBattle, classNam
               ) : (
                 <>
                   {activeBattles.map((battle) => (
-                    <BattleCard key={battle.id} battle={battle} players={players} onWatch={onWatchBattle} />
+                    <BattleCard key={battle.id} battle={battle} players={players} onWatch={onWatchBattle} onViewOnGlobe={onViewOnGlobe} />
                   ))}
                   {recentBattles.length > 0 && (
                     <>
                       <p className="text-xs text-muted-foreground uppercase font-display tracking-wide pt-2">Recent</p>
                       {recentBattles.map((battle) => (
-                        <BattleCard key={battle.id} battle={battle} players={players} onWatch={onWatchBattle} />
+                        <BattleCard key={battle.id} battle={battle} players={players} onWatch={onWatchBattle} onViewOnGlobe={onViewOnGlobe} />
                       ))}
                     </>
                   )}

--- a/client/src/lib/algorand.ts
+++ b/client/src/lib/algorand.ts
@@ -422,7 +422,7 @@ export function getCachedAsaId(): number | null {
 // an atomic group. A hard MAX_WAIT_MS cap prevents indefinite queueing.
 // ---------------------------------------------------------------------------
 
-export const MAX_GROUP_SIZE = 8;
+export const MAX_GROUP_SIZE = 16;
 export const BATCH_WINDOW_MS = 800;
 export const MAX_WAIT_MS = 2000;
 
@@ -440,7 +440,7 @@ type BatchSignCallback = (actions: BatchedAction[]) => Promise<string | null>;
 // Increase MAX_ACTIONS to allow more actions to accumulate before flushing.
 // The "Satellite Relay" framing makes this feel like a game mechanic, not lag.
 const MAX_BATCH_NOTE_BYTES   = 1000;  // stay under Algorand's 1024-byte limit
-const MAX_ACTIONS_PER_FLUSH  = 8;     // Hard cap: flush before Algorand's 16-txn group limit
+const MAX_ACTIONS_PER_FLUSH  = 16;    // Hard cap: Algorand's 16-txn group limit
 const FLUSH_INTERVAL_MS      = 5_000; // Relay window: 5 seconds (was 15s — prevents overrun)
 const FLUSH_MAX_WAIT_MS      = 15_000; // Never hold longer than 15 seconds (was 45s)
 interface TxnQueueEntry {


### PR DESCRIPTION
- BattlesPanel/WarRoomPanel: add "View Plot" button on each battle card
  that switches to the map tab and centers the globe on the target parcel

- GameLayout: wire handleViewOnGlobe to both panels; randomise
  handleLocateTerritory (green button) and handleFindEnemyTarget (red
  button) so each click picks a different plot from the last one shown,
  using a ref to track the previous selection

- FlatMap: simplify handleLocate (centering now driven by the
  selectedParcelId effect); always center globe on newly selected parcel
  so locate/enemy/battle-link navigations reliably bring the plot into view

- algorand.ts: raise MAX_GROUP_SIZE and MAX_ACTIONS_PER_FLUSH from 8 → 16
  to match Algorand's atomic group limit and avoid transaction splits

https://claude.ai/code/session_01WKyWmmsNMKFERd9wmGRzRw