### PR TITLE
feat: first plot free — skip ALGO fee and wallet requirement in tutorial

### DIFF
--- a/client/src/components/game/GameLayout.tsx
+++ b/client/src/components/game/GameLayout.tsx
@@ -375,10 +375,14 @@ export function GameLayout() {
     );
   };
 
+  const isFreeClaimEligible = (player?.territoriesCaptured ?? 0) === 0;
+
   const handlePurchase = async () => {
     if (!player || !selectedParcelId || !selectedParcel) return;
 
-    if (!isWalletConnected) {
+    // First plot is free — no wallet or ALGO signing required.
+    // All subsequent plots require a connected wallet and ALGO payment.
+    if (!isFreeClaimEligible && !isWalletConnected) {
       toast({
         title: "Wallet Required",
         description: "Connect your Algorand wallet to purchase territory.",
@@ -387,7 +391,7 @@ export function GameLayout() {
       return;
     }
 
-    if (selectedParcel.purchasePriceAlgo !== null) {
+    if (!isFreeClaimEligible && selectedParcel.purchasePriceAlgo !== null) {
       const result = await signPurchaseAction(selectedParcel.plotId, selectedParcel.purchasePriceAlgo);
       if (result === "cancelled") return;
     }
@@ -1255,6 +1259,7 @@ export function GameLayout() {
           onClaim={handlePurchase}
           isClaiming={purchaseMutation.isPending}
           isWalletConnected={isWalletConnected}
+          isFreeClaimEligible={isFreeClaimEligible}
           onOpenFullSheet={() => {
             setShowFullLandSheet(true);
             tutorial.notifyEvent("landsheet_opened");

--- a/client/src/components/game/MobilePlotSheet.tsx
+++ b/client/src/components/game/MobilePlotSheet.tsx
@@ -90,7 +90,7 @@ export function MobilePlotSheet({
   const biomeLabel = BIOME_LABELS[parcel.biome] ?? parcel.biome;
   const { label: richnessLabel, className: richnessClass } = richnessBadge(parcel.richness);
 
-  const showClaimCta = isUnclaimed && player && isWalletConnected;
+  const showClaimCta = isUnclaimed && player && (isFreeClaimEligible || isWalletConnected);
   const claimPrice = parcel.purchasePriceAlgo;
   const priceLabel = isFreeClaimEligible ? "FREE" : claimPrice !== null ? `${claimPrice} ALGO` : "—";
 

--- a/client/src/components/game/SelectedPlotPanel.tsx
+++ b/client/src/components/game/SelectedPlotPanel.tsx
@@ -255,7 +255,7 @@ function DesktopPlotPanel({
 
           {/* CTA — always visible at panel bottom */}
           <div className="flex-shrink-0 px-4 pb-4 pt-2 border-t border-border/50 bg-card/90 space-y-2">
-            {isUnclaimed && player && isWalletConnected && (
+            {isUnclaimed && player && (isFreeClaimEligible || isWalletConnected) && (
               <Button
                 size="lg"
                 className={cn(
@@ -281,7 +281,7 @@ function DesktopPlotPanel({
               </Button>
             )}
 
-            {isUnclaimed && (!player || !isWalletConnected) && (
+            {isUnclaimed && (!player || (!isFreeClaimEligible && !isWalletConnected)) && (
               <Button size="lg" variant="outline" className="w-full font-display uppercase tracking-widest" disabled>
                 Connect Wallet to Claim
               </Button>

--- a/client/src/hooks/useTutorial.ts
+++ b/client/src/hooks/useTutorial.ts
@@ -45,9 +45,9 @@ export const TUTORIAL_STEPS: TutorialStep[] = [
   },
   {
     id: "buy-plot",
-    title: "Buy Your First Plot",
+    title: "Claim Your First Plot — Free",
     description:
-      "You've selected a plot. If it's unclaimed, hit Acquire Territory to own it. Ownership earns FRONTIER tokens and lets you build, mine, and defend.",
+      "Your first plot is on us. Hit Claim Free Plot to own it — no wallet or ALGO needed. Ownership earns FRONTIER tokens and lets you build, mine, and defend.",
     target: "acquire-territory",
     completionRule: "plot_purchased",
   },

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1205,15 +1205,19 @@ export async function registerRoutes(
       const player = await storage.getPlayer(action.playerId);
       if (!player) return res.status(404).json({ error: "Player not found" });
 
-      // Reject purchases from placeholder/unconnected wallet addresses.
-      // This mirrors the client-side guard and cannot be bypassed by direct API calls.
-      if (
-        !player.address ||
-        player.address === "PLAYER_WALLET" ||
-        player.address.startsWith("AI_") ||
-        !algosdk.isValidAddress(player.address)
-      ) {
-        return res.status(403).json({ error: "A connected Algorand wallet is required to purchase territory." });
+      // First plot is free — no wallet required.
+      // All subsequent plots require a connected Algorand wallet.
+      const isFirstPlot = (player.territoriesCaptured ?? 0) === 0;
+
+      if (!isFirstPlot) {
+        if (
+          !player.address ||
+          player.address === "PLAYER_WALLET" ||
+          player.address.startsWith("AI_") ||
+          !algosdk.isValidAddress(player.address)
+        ) {
+          return res.status(403).json({ error: "A connected Algorand wallet is required to purchase territory." });
+        }
       }
 
       const buyerAddress = player.address;
@@ -1231,7 +1235,8 @@ export async function registerRoutes(
         metadata: { plotId: parcel.plotId, playerName: buyerForEvent?.name ?? "Unknown", biome: parcel.biome }
       });
 
-      // Mint a Plot NFT (Algorand ASA) for human players only.
+      // Mint a Plot NFT (Algorand ASA) for human players with connected wallets.
+      // First-plot free claims may not have a valid wallet yet — skip NFT for those.
       let nftAssetId: number | null = null;
       const isHumanBuyer =
         buyerAddress &&


### PR DESCRIPTION
- Compute isFreeClaimEligible (territoriesCaptured === 0) in GameLayout and
  pass it down to SelectedPlotPanel / MobilePlotSheet so the UI shows
  "Claim Free Plot" and the emerald free-claim styling that was already built
  but never wired up
- Skip signPurchaseAction() on the client when isFreeClaimEligible so no
  ALGO transaction is prompted, unblocking the tutorial purchase step
- Show the claim button even without a connected wallet for first-plot claims
  (both desktop panel and mobile sheet)
- Server: bypass the Algorand wallet address check for a player's first
  purchase (territoriesCaptured === 0); NFT minting still fires if a valid
  wallet address is present, silently skips if not
- Update tutorial step text to clearly communicate the free first plot offer

https://claude.ai/code/session_015eVs8KFJFbXMWHuxCPc3SZ